### PR TITLE
First draft of validity code for loading from jsonl files

### DIFF
--- a/src/legendmeta/Props.py
+++ b/src/legendmeta/Props.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 Oliver Schulz <oschulz@mpp.mpg.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from collections import namedtuple
+import types
+import collections
+import json
+import copy
+import os
+from string import Template
+
+class Props():
+    @staticmethod
+    def read_from(sources, subst_pathvar = False, subst_env = False, trim_null = False):
+        def read_impl(sources):
+            if isinstance(sources, str):
+                file_name = sources
+                with open(file_name, 'r') as file:
+                    result = json.load(file)
+                    if subst_pathvar:
+                        Props.subst_vars(
+                            result,
+                            var_values = {'_': os.path.dirname(file_name)},
+                            use_env = False, ignore_missing = True
+                        )
+                    return result
+
+            elif isinstance(sources, list):
+                result = {}
+                for p in map(read_impl, sources):
+                    Props.add_to(result, p)
+                return result
+            else:
+                raise ValueError(f"Can't run Props.read_from on sources-value of type {type(sources)}")
+
+        result = read_impl(sources)
+        if subst_env:
+            Props.subst_vars(result, var_values = {}, use_env = True, ignore_missing = False)
+        if trim_null:
+            Props.trim_null(result)
+        return result
+
+
+    @staticmethod
+    def write_to(file_name, obj, pretty = False):
+        separators = None if pretty else (',', ':')
+        indent = 2 if pretty else None
+        with open(file_name, 'w') as file:
+            json.dump(obj, file, indent = indent, separators = separators)
+            file.write('\n')
+
+
+    @staticmethod
+    def add_to(props_a, props_b):
+        a = props_a
+        b = props_b
+
+        for key in b:
+            if key in a:
+                if isinstance(a[key], dict) and isinstance(b[key], dict):
+                    Props.add_to(a[key], b[key])
+                elif a[key] != b[key]:
+                    a[key] = copy.copy(b[key])
+            else:
+                a[key] = copy.copy(b[key])
+
+
+    @staticmethod
+    def subst_vars(props, var_values = {}, use_env = False, ignore_missing = False):
+        combined_var_values = var_values
+        if use_env:
+            combined_var_values = env_list(var_values)
+        for key in props:
+            value = props[key]
+            if isinstance(value, str) and '$' in value:
+                new_value = None
+                if ignore_missing:
+                    new_value = Template(value).safe_substitute(combined_var_values)
+                else:
+                    new_value = Template(value).substitute(combined_var_values)
+
+                if (new_value != value):
+                    props[key] = new_value
+            elif isinstance(value, dict):
+                Props.subst_vars(value, combined_var_values, False, ignore_missing)
+
+
+    @staticmethod
+    def trim_null(props_a):
+        a = props_a
+
+        for key in a.keys():
+            if isinstance(a[key], dict):
+                Props.trim_null(a[key])
+            elif a[key] is None:
+                del a[key]

--- a/src/legendmeta/catalog.py
+++ b/src/legendmeta/catalog.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015 Oliver Schulz <oschulz@mpp.mpg.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from collections import namedtuple
+import bisect
+import types
+import collections
+import json
+import copy
+import os
+from string import Template
+from datetime import datetime
+
+def unix_time(value):
+    if isinstance(value, str):
+        return datetime.timestamp(datetime.strptime(value, '%Y%m%dT%H%M%SZ'))
+    else:
+        raise ValueError(f"Can't convert type {type(value)} to unix time")
+
+class PropsStream():
+    @staticmethod
+    def get(value):
+        if isinstance(value, str):
+            return PropsStream.read_from(value)
+        elif isinstance(value, collections.Sequence) or isinstance(value, types.GeneratorType):
+            return value
+        else:
+            raise ValueError(f"Can't get PropsStream from value of type {type(source)}")
+
+
+    @staticmethod
+    def read_from(file_name):
+        with open(file_name, 'r') as file:
+            for json_str in file:
+                yield json.loads(json_str)
+
+class Catalog(namedtuple('Catalog', ['entries'])):
+    __slots__ = ()
+
+    class Entry(namedtuple('Entry', ['valid_from','file'])):
+        __slots__ = ()
+
+
+    @staticmethod
+    def get(value):
+        if isinstance(value, Catalog):
+            return value
+        if isinstance(value, str):
+            return Catalog.read_from(value)
+        else:
+            raise ValueError(f"Can't get Catalog from value of type {type(source)}")
+
+
+    @staticmethod
+    def read_from(file_name):
+        entries = {}
+
+        for props in PropsStream.get(file_name):
+            timestamp = props["valid_from"]
+            if props.get("select") is None:
+                system = "all"
+            else:
+                system = props["select"]
+            file_key = props["apply"]
+            if system not in entries:
+                entries[system] = []
+            entries[system].append(Catalog.Entry(unix_time(timestamp),file_key))
+
+        for system in entries:
+            entries[system] = sorted(
+                entries[system],
+                key = lambda entry: entry.valid_from
+            )
+        return Catalog(entries)
+
+
+    def valid_for(self, timestamp, system="all", allow_none = False):
+        if system in self.entries:
+            valid_from = [ entry.valid_from for entry in self.entries[system]]
+            pos = bisect.bisect_right(valid_from, unix_time(timestamp))
+            if pos > 0:
+                return self.entries[system][pos - 1].file
+            else:
+                if allow_none: return None
+                else: raise RuntimeError(f'No valid entries found for timestamp: {timestamp}, system: {system}')
+        else:
+            if allow_none: return None
+            else: raise RuntimeError(f'No entries found for system: {system}')
+    
+    @staticmethod
+    def get_files(catalog_file, timestamp, category="all"):
+        catalog = Catalog.read_from(catalog_file)
+        return Catalog.valid_for(catalog,timestamp, category)
+    

--- a/src/legendmeta/jsondb.py
+++ b/src/legendmeta/jsondb.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import re
 from pathlib import Path
 from typing import Iterator
+from legendmeta.Props import Props
+from legendmeta.catalog import Catalog
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +37,7 @@ class JsonDB:
     >>> jdb["dir1"]["file1"]  # nested JSON file
     >>> jdb["dir1/file1"]  # also works
     """
+    tstamp_form = re.compile("\d{8}T\d{6}Z")
 
     def __init__(self, path: str | Path) -> None:
         self.path: Path = Path(path).expanduser().resolve()
@@ -49,6 +54,47 @@ class JsonDB:
             except (json.JSONDecodeError, ValueError):
                 log.warning(f"could not scan file {j}")
 
+    def _time_validity(self, timestamp:str|datetime, system="cal", pattern=None) -> JsonDB | dict:
+        key_resolve = os.path.join(self.path, "key_resolve.jsonl")
+        file_list = Catalog.get_files(key_resolve, timestamp, system)
+        #select only files matching pattern if specfied
+        if pattern is not None:
+            c = re.compile(pattern)
+            out_files = []
+            for file in file_list:
+                if c.match(file):
+                    out_files.append(file)
+            return out_files
+        else: return file_list
+        
+    def __gettstamp__(self, d) ->  dict:
+        db_ptr = self
+        #define defaults
+        pattern=None
+        system="all"
+        #check if system or file pattern is specified
+        if len(d)>16:
+            if d.count(",")==2:
+                d, system, pattern = d.split(",")
+            elif d.count(",")==1:
+                d,system = d.split(",")
+        # get the files from the jsonl
+        files = self._time_validity(d,system=system, pattern=pattern)
+
+        # read files in and combine as necessary
+        if isinstance(files, list):
+            result={}
+            for file in files:
+                fp = self.path.rglob(file)
+                fp = [i for i in fp][0]
+                Props.add_to(result, db_ptr[fp])
+            db_ptr = result
+        else:
+            fp = self.path.rglob(file)
+            fp = [i for i in fp][0]
+            db_ptr = db_ptr[fp]
+        return db_ptr
+
     def __getitem__(self, item: str | Path) -> JsonDB | dict:
         """Access files or directories in the database."""
         # resolve relative paths / links, but keep it relative to self.path
@@ -56,6 +102,8 @@ class JsonDB:
 
         # now call this very function recursively to walk the directories to the file
         db_ptr = self
+        if (isinstance(item.parts[0], str) and self.tstamp_form.match(item.parts[0][:16])):
+            return self.__gettstamp__(item.parts[0])
         for d in item.parts[0:-1]:
             db_ptr = db_ptr[d]
 


### PR DESCRIPTION
Added the props and propstream for loading and combining json files from a jsonl lookup. Integrated into the get_item method. At the moment I have just used a very rough syntax which is "timestamp,system,pattern". If just the timestamp is given the system is taken to be all and all the json files found are combined. A pattern in the form of a regular expression e.g \*-par_hit.json can be specified to only choose one type of file which is needed for the par files.  