### PR TITLE
Bump SQLAlchemy version bound to `>=2`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ packages = find:
 install_requires =
     GitPython
     pandas
-    sqlalchemy>=2.*
+    sqlalchemy>=2
 python_requires = >=3.9
 include_package_data = True
 package_dir =


### PR DESCRIPTION
Now that v2.0.0 is finally released.