### PR TITLE
pin psycopg2-binary on macOS/python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "GitPython",
     "pandas",
     "pyyaml",
-    "psycopg2-binary",
+    "psycopg2-binary<=2.9.9; python_version<'3.10' and platform_system=='Darwin'",
+    "psycopg2-binary; python_version>='3.10' or platform_system!='Darwin'",
     "sqlalchemy>=2",
 ]
 dynamic = [


### PR DESCRIPTION
There are no psycopg2-binary wheels for python 3.9 on the github macOS-latest (arm64) runner.

* Upstream states it would not possible any more to produce wheels for this combination.
* This would (probably) fix the macOS-latest CI jobs for all our packages dependant on pylegendmeta
* but this would (unfortunately) also limit actual users from building newer wheels from source on their machines...