### PR TITLE
channelmap updates

### DIFF
--- a/src/legendmeta/core.py
+++ b/src/legendmeta/core.py
@@ -103,7 +103,7 @@ class LegendMetadata(TextDB):
         self._repo.git.checkout(self._default_git_ref)
 
     def channelmap(
-        self, on: str | datetime | None = None, system: str = "all"
+        self, on: str | datetime | None = None, system: str | None = None
     ) -> AttrsDict:
         """Get a LEGEND channel map.
 
@@ -118,7 +118,8 @@ class LegendMetadata(TextDB):
             a :class:`~datetime.datetime` object or a string matching the
             pattern ``YYYYmmddTHHMMSSZ``.
         system: 'all', 'phy', 'cal', 'lar', ...
-            query only a data taking "system".
+            query only a data taking "system". If on is None, default to
+            'all', otherwise this must be provided
 
         Warning
         -------
@@ -136,12 +137,21 @@ class LegendMetadata(TextDB):
         >>> channel.analysis.usability
         'on'
 
+        >>> channel = lmeta.channelmap(on=datetime.now(), system='cal').V05267B
+
         See Also
         --------
         .textdb.TextDB.on
         """
         if on is None:
             on = datetime.now()
+            if system is None:
+                system = "all"
+
+        if system is None:
+            msg = "System cannot be None. Provide a value (e.g. 'all', 'cal', 'phy', etc.)"
+            raise ValueError(msg)
+
 
         chmap = self.hardware.configuration.channelmaps.on(
             on, pattern=None, system=system


### PR DESCRIPTION
Updated behavior of channelmap arguments

- If an `on` argument is provided, a `system` argument must be provided or an error will be thrown. If no `on` is provided default to `"all"`. This has the goal of avoiding confusion/ambiguity caused by the `"all"` default. See https://github.com/legend-exp/pylegendmeta/issues/76
- For `on` can provide period and run instead of just a timestamp. This will use the runinfo database to look up the timestamp. This is just a mild QoL improvement to interfacing with it.