### PR TITLE
fix empty-string LEGEND_METADATA env var

### DIFF
--- a/src/legendmeta/core.py
+++ b/src/legendmeta/core.py
@@ -54,9 +54,11 @@ class LegendMetadata(TextDB):
         if isinstance(path, str):
             self.__repo_path__ = path
         else:
-            self.__repo_path__ = os.getenv(
-                "LEGEND_METADATA",
-                str(Path(gettempdir()) / ("legend-metadata-" + getuser())),
+            self.__repo_path__ = os.getenv("LEGEND_METADATA", "")
+
+        if self.__repo_path__ == "":
+            self.__repo_path__ = str(
+                Path(gettempdir()) / ("legend-metadata-" + getuser())
             )
 
         # self.__repo__: Repo =


### PR DESCRIPTION
it is quite common to use `ENV_VAR= command --args ...` for this to unset an env var for a command

until now (in stable versions), pylegendmeta did try to use the current directory as a metadata repo.
* if ${CWD} was a git repo, it probably just failed later on, when something else does not find the right data.
* if ${CWD} was not a git repo, it fails right away with
  ```
  git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
    cmdline: git clone -v --recurse-submodules -- git@github.com:legend-exp/legend-metadata 
    stderr: 'fatal: could not create work tree dir '': No such file or directory
  ```


with the changes from #75. this might have bad consequences on unrelated git repos, as now legendmeta does try to check out tags in the git repo.

The solution implemented here treats an empty path as if `None` had been passed.  The other option would be to throw an exception if an empty path is provided.