### PR TITLE
Automatically add repo to safe directories list in git user config

### DIFF
--- a/src/legendmeta/core.py
+++ b/src/legendmeta/core.py
@@ -283,5 +283,7 @@ class LegendMetadata(TextDB):
             self.__repo__.git.rev_parse("HEAD")
         except GitCommandError as e:
             if "fatal: detected dubious ownership" in e.stderr:
+                msg = f"git raised dubious ownership error. Automatically called 'git config --global --add safe.directory {self.__repo_path__}`"
+                log.warning(msg)
                 with self.__repo__.config_writer("global") as c:
                     c.add_value("safe", "directory", str(self.__repo_path__))


### PR DESCRIPTION
Fix for:
```
GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git describe --tags --always --match=v[0-9]*[0-9]*[0-9]* --abbrev=0
  stderr: 'fatal: detected dubious ownership in repository at [path]
To add an exception for this directory, call:

	git config --global --add safe.directory [path]
```

This catches the error when we are verifying that we are looking at a repository, and calls `git config --global --add safe.directory [path]`. This has the effect of modifying `~/.gitconfig`!