### PR TITLE
Fix import error when building docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
-
 from importlib import metadata
+from pathlib import Path
 
 sys.path.insert(0, Path(__file__).parents[2].resolve().as_posix())
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from pkg_resources import get_distribution
+from importlib import metadata
 
 sys.path.insert(0, Path(__file__).parents[2].resolve().as_posix())
 
 project = "pylegendmeta"
 copyright = "The LEGEND Collaboration"
-version = get_distribution("pylegendmeta").version
+version = metadata.version("pylegendmeta")
 
 extensions = [
     "sphinx.ext.githubpages",


### PR DESCRIPTION
With python 3.12, pkg_resources is deprecated; instead use importlib