### PR TITLE
Test coverage for channel-map key/name check and status-in-chmap validation, add sorting functions

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -19,21 +19,21 @@
 
 - id: validate-statuses
   name: check LEGEND status files format
-  entry: validate-statuses
+  entry: validate-statuses --fix
   language: python
   files: (.*\/)?validity\..+$
   types_or: [yaml, json]
 
 - id: validate-cal-groupings
   name: check LEGEND calibration groupings format
-  entry: validate-cal-groupings
+  entry: validate-cal-groupings --fix
   language: python
   files: (.*\/)?cal_groupings\..+$
   types: [yaml]
 
 - id: validate-phy-groupings
   name: check LEGEND physics groupings format
-  entry: validate-phy-groupings
+  entry: validate-phy-groupings --fix
   language: python
   files: (.*\/)?phy_groupings\..+$
   types: [yaml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ namespaces = false
 attr = "legendmeta._version.version"
 
 [tool.codespell]
-ignore-words-list = "crate,nd,unparseable,compiletime"
+ignore-words-list = "crate,nd,unparseable,compiletime,puls"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -314,7 +314,7 @@ def validate_statuses() -> None:
                 continue
 
             try:
-                chmap = meta.channelmap(ts)
+                chmap = meta.hardware.configuration.channelmaps.on(ts)
             except Exception as e:
                 print(f"WARNING: could not load channel map at '{ts}': {e}")  # noqa: T201
                 chmap = None

--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -120,11 +120,7 @@ def validate_legend_channel_map() -> bool:
                         )
                         continue
 
-                    if "name" in v and v["name"] != k:
-                        print(  # noqa: T201
-                            f"ERROR: '{k}': key does not match 'name' field '{v['name']}'"
-                        )
-                        valid *= False
+                    valid *= _check_chmap_key_name(k, v)
 
                     valid *= validate_dict_schema(
                         v,
@@ -136,6 +132,17 @@ def validate_legend_channel_map() -> bool:
 
         if not valid:
             sys.exit(1)
+
+
+def _check_chmap_key_name(key: str, entry: dict, verbose: bool = True) -> bool:
+    """Return True if entry's 'name' field is absent or matches the dict key."""
+    if "name" in entry and entry["name"] != key:
+        if verbose:
+            print(  # noqa: T201
+                f"ERROR: '{key}': key does not match 'name' field '{entry['name']}'"
+            )
+        return False
+    return True
 
 
 def validate_dict_schema(

--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -25,6 +25,7 @@ import yaml
 from dbetto import Props, TextDB, utils
 from dbetto.catalog import Catalog
 
+from .legendmetadata import LegendMetadata
 from .utils import _RUN_RANGE_PATTERN, expand_runs
 
 templates = resources.files("legendmeta") / "templates"
@@ -91,7 +92,7 @@ def validate_legend_channel_map() -> bool:
     args = parser.parse_args()
 
     dict_temp = {}
-    for typ in ("geds", "spms"):
+    for typ in ("geds", "spms", "pmts", "auxs", "bsln", "puls"):
         dict_temp[typ] = utils.load_dict(templates / f"{typ}-channel.yaml")
 
     for d in {Path(f).parent for f in args.files}:
@@ -118,6 +119,12 @@ def validate_legend_channel_map() -> bool:
                             f"WARNING: '{k}': no template for system '{v['system']}' entry"
                         )
                         continue
+
+                    if "name" in v and v["name"] != k:
+                        print(  # noqa: T201
+                            f"ERROR: '{k}': key does not match 'name' field '{v['name']}'"
+                        )
+                        valid *= False
 
                     valid *= validate_dict_schema(
                         v,
@@ -289,6 +296,8 @@ def validate_statuses() -> None:
     parser.add_argument("files", nargs="+", help="validity files")
     args = parser.parse_args()
 
+    meta = LegendMetadata()
+
     valid = True
     for validity_file in args.files:
         d = Path(validity_file).parent
@@ -304,9 +313,19 @@ def validate_statuses() -> None:
                 valid = False
                 continue
 
+            try:
+                chmap = meta.channelmap(ts)
+            except Exception as e:
+                print(f"WARNING: could not load channel map at '{ts}': {e}")  # noqa: T201
+                chmap = None
+
             for ch, entry in state.items():
                 if not isinstance(entry, dict):
                     continue
+
+                if chmap is not None and ch not in chmap:
+                    print(f"ERROR: '{ch}' at '{ts}': key not found in channel map")  # noqa: T201
+                    valid = False
 
                 is_ge = ch.startswith(_GE_PREFIXES) and not ch.startswith("PMT")
                 is_sipm = ch.startswith(_SIPM_PREFIXES)

--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -482,7 +482,7 @@ def _fix_groupings_file(file: str) -> bool:
     """Sort a groupings file in place. Returns True if the file was modified."""
     data = utils.load_dict(file)
     sorted_data = _sort_groupings_data(data)
-    if not _needs_reorder(data, sorted_data):
+    if not (_needs_reorder(data, sorted_data) or data != sorted_data):
         return False
     with Path(file).open("w") as f:
         yaml.dump(

--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -301,9 +301,19 @@ def validate_statuses() -> None:
         prog="validate-statuses", description="Validate LEGEND status files"
     )
     parser.add_argument("files", nargs="+", help="validity files")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="sort status entry keys in place instead of reporting errors",
+    )
     args = parser.parse_args()
 
     meta = LegendMetadata()
+
+    modified = False
+    if args.fix:
+        for validity_file in args.files:
+            modified |= _fix_status_files(validity_file)
 
     valid = True
     for validity_file in args.files:
@@ -397,8 +407,130 @@ def validate_statuses() -> None:
                                 )
                                 valid = False
 
-    if not valid:
+    if modified or not valid:
         sys.exit(1)
+
+
+_STATUS_KEY_ORDER = ("reason", "usability", "processable", "is_blinded", "psd")
+_PSD_KEY_ORDER = ("is_bb_like", "status")
+
+
+def _sort_status_entry(entry: dict) -> dict:
+    """Return a copy of a channel status entry with keys in canonical order."""
+    result = {}
+    for key in _STATUS_KEY_ORDER:
+        if key not in entry:
+            continue
+        if key == "psd" and isinstance(entry[key], dict):
+            psd = entry[key]
+            sorted_psd = {k: psd[k] for k in _PSD_KEY_ORDER if k in psd}
+            sorted_psd.update({k: v for k, v in psd.items() if k not in sorted_psd})
+            result[key] = sorted_psd
+        else:
+            result[key] = entry[key]
+    result.update({k: v for k, v in entry.items() if k not in result})
+    return result
+
+
+def _needs_reorder(a: dict, b: dict) -> bool:
+    """Return True if key order differs (recursively) between a and b."""
+    if list(a.keys()) != list(b.keys()):
+        return True
+    for k, v in a.items():
+        if (
+            isinstance(v, dict)
+            and isinstance(b.get(k), dict)
+            and _needs_reorder(v, b[k])
+        ):
+            return True
+    return False
+
+
+def _sort_groupings_groups(groups: dict) -> dict:
+    """Return a copy of a groups dict with groups and periods/runs sorted."""
+    result = {}
+    for group in sorted(groups):
+        periods = groups[group]
+        if not isinstance(periods, dict):
+            result[group] = periods
+            continue
+        sorted_periods = {}
+        for period in sorted(str(p) for p in periods):
+            runs = periods[period]
+            sorted_periods[period] = (
+                sorted(runs, key=_run_sort_key) if isinstance(runs, list) else runs
+            )
+        result[group] = sorted_periods
+    return result
+
+
+def _sort_groupings_data(data: dict) -> dict:
+    """Return a copy of groupings data with all keys sorted, default first."""
+    result = {}
+    if "default" in data:
+        val = data["default"]
+        result["default"] = (
+            _sort_groupings_groups(val) if isinstance(val, dict) else val
+        )
+    for key in sorted(k for k in data if k != "default"):
+        val = data[key]
+        result[key] = _sort_groupings_groups(val) if isinstance(val, dict) else val
+    return result
+
+
+def _fix_groupings_file(file: str) -> bool:
+    """Sort a groupings file in place. Returns True if the file was modified."""
+    data = utils.load_dict(file)
+    sorted_data = _sort_groupings_data(data)
+    if not _needs_reorder(data, sorted_data):
+        return False
+    with Path(file).open("w") as f:
+        yaml.dump(
+            sorted_data,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )
+    print(f"Fixed: sorted keys in '{file}'")  # noqa: T201
+    return True
+
+
+def _fix_status_files(validity_file: str) -> bool:
+    """Sort channel entry keys in all status YAML files beside the validity file.
+
+    Returns True if any file was modified.
+    """
+    d = Path(validity_file).parent
+    modified = False
+    for yaml_file in sorted(d.glob("*.yaml")):
+        if yaml_file.name == "validity.yaml":
+            continue
+        data = utils.load_dict(str(yaml_file))
+        if not isinstance(data, dict):
+            continue
+        sorted_data = {}
+        changed = False
+        for ch, entry in data.items():
+            if isinstance(entry, dict):
+                sorted_entry = _sort_status_entry(entry)
+                sorted_data[ch] = sorted_entry
+                if _needs_reorder(entry, sorted_entry):
+                    changed = True
+            else:
+                sorted_data[ch] = entry
+        if changed:
+            with yaml_file.open("w") as f:
+                yaml.dump(
+                    sorted_data,
+                    f,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                )
+            print(f"Fixed: sorted keys in '{yaml_file}'")  # noqa: T201
+            modified = True
+    return modified
 
 
 def _run_sort_key(spec: str) -> str:
@@ -667,10 +799,19 @@ def validate_cal_groupings() -> None:
         description="Validate LEGEND calibration groupings files",
     )
     parser.add_argument("files", nargs="+", help="cal_groupings files")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="sort groupings files in place instead of reporting errors",
+    )
     args = parser.parse_args()
 
+    modified = False
     valid = True
     for file in args.files:
+        if args.fix:
+            modified |= _fix_groupings_file(file)
+
         d = Path(file).parent
         run_override_path = d / "run_override.yaml"
         runinfo_path = d / "runinfo.yaml"
@@ -693,7 +834,7 @@ def validate_cal_groupings() -> None:
         if overridden:
             valid &= _check_cal_override_runs(file, overridden)
 
-    if not valid:
+    if modified or not valid:
         sys.exit(1)
 
 
@@ -707,11 +848,19 @@ def validate_phy_groupings() -> None:
         description="Validate LEGEND physics groupings files",
     )
     parser.add_argument("files", nargs="+", help="phy_groupings files")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="sort groupings files in place instead of reporting errors",
+    )
     args = parser.parse_args()
 
+    modified = False
     valid = True
     for file in args.files:
+        if args.fix:
+            modified |= _fix_groupings_file(file)
         valid &= _validate_groupings_file(file, "phygroup")
 
-    if not valid:
+    if modified or not valid:
         sys.exit(1)

--- a/src/legendmeta/templates/auxs-channel.yaml
+++ b/src/legendmeta/templates/auxs-channel.yaml
@@ -1,0 +1,2 @@
+name: ^(DUMMY\d{2}|MUON01)$
+system: auxs

--- a/src/legendmeta/templates/bsln-channel.yaml
+++ b/src/legendmeta/templates/bsln-channel.yaml
@@ -1,0 +1,2 @@
+name: ^BSLN\d{2}$
+system: bsln

--- a/src/legendmeta/templates/geds-channel.yaml
+++ b/src/legendmeta/templates/geds-channel.yaml
@@ -1,4 +1,4 @@
-name: ^[VPBC]\w{6}$
+name: ^([VBP]\d{5}[A-Z]|C00ANG\d|C000RG\d)$
 system: geds
 location:
   string: 0

--- a/src/legendmeta/templates/pmts-channel.yaml
+++ b/src/legendmeta/templates/pmts-channel.yaml
@@ -1,0 +1,2 @@
+name: ^PMT\d{3}$
+system: pmts

--- a/src/legendmeta/templates/puls-channel.yaml
+++ b/src/legendmeta/templates/puls-channel.yaml
@@ -1,0 +1,2 @@
+name: ^PULS\d{2}(ANA)?$
+system: puls

--- a/tests/test_police.py
+++ b/tests/test_police.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 import yaml
 
 from legendmeta import police
@@ -377,6 +376,8 @@ def test_validate_statuses_chmap_unavailable_skips_check(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["validate-statuses", str(validity_file)])
     with patch("legendmeta.police.LegendMetadata", return_value=mock_meta):
         police.validate_statuses()  # chmap unavailable → no error
+
+
 # _needs_reorder
 # ---------------------------------------------------------------------------
 

--- a/tests/test_police.py
+++ b/tests/test_police.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import yaml
+
 from legendmeta import police
 
 
@@ -375,3 +377,309 @@ def test_validate_statuses_chmap_unavailable_skips_check(tmp_path, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["validate-statuses", str(validity_file)])
     with patch("legendmeta.police.LegendMetadata", return_value=mock_meta):
         police.validate_statuses()  # chmap unavailable → no error
+# _needs_reorder
+# ---------------------------------------------------------------------------
+
+
+def test_needs_reorder_same_order():
+    assert not police._needs_reorder({"a": 1, "b": 2}, {"a": 1, "b": 2})
+
+
+def test_needs_reorder_different_order():
+    assert police._needs_reorder({"b": 2, "a": 1}, {"a": 1, "b": 2})
+
+
+def test_needs_reorder_nested_same():
+    a = {"x": {"b": 2, "a": 1}}
+    b = {"x": {"b": 2, "a": 1}}
+    assert not police._needs_reorder(a, b)
+
+
+def test_needs_reorder_nested_different():
+    a = {"x": {"b": 2, "a": 1}}
+    b = {"x": {"a": 1, "b": 2}}
+    assert police._needs_reorder(a, b)
+
+
+def test_needs_reorder_non_dict_values_ignored():
+    # Only key order matters; non-dict values are not compared
+    assert not police._needs_reorder({"a": [3, 1, 2]}, {"a": [1, 2, 3]})
+
+
+# ---------------------------------------------------------------------------
+# _sort_status_entry
+# ---------------------------------------------------------------------------
+
+_FULL_ENTRY_SORTED = {
+    "reason": "",
+    "usability": "on",
+    "processable": True,
+    "is_blinded": True,
+    "psd": {
+        "is_bb_like": "low_aoe & high_aoe",
+        "status": {"low_aoe": "valid", "high_aoe": "valid"},
+    },
+}
+
+
+def test_sort_status_entry_already_sorted():
+    result = police._sort_status_entry(_FULL_ENTRY_SORTED)
+    assert list(result.keys()) == list(_FULL_ENTRY_SORTED.keys())
+    assert list(result["psd"].keys()) == list(_FULL_ENTRY_SORTED["psd"].keys())
+
+
+def test_sort_status_entry_reorders_keys():
+    scrambled = {
+        "processable": True,
+        "is_blinded": True,
+        "usability": "on",
+        "reason": "",
+        "psd": {
+            "status": {"low_aoe": "valid"},
+            "is_bb_like": "low_aoe",
+        },
+    }
+    result = police._sort_status_entry(scrambled)
+    assert list(result.keys()) == [
+        "reason",
+        "usability",
+        "processable",
+        "is_blinded",
+        "psd",
+    ]
+    assert list(result["psd"].keys()) == ["is_bb_like", "status"]
+
+
+def test_sort_status_entry_missing_keys():
+    # Entries without psd/is_blinded/reason (e.g. early SiPM entries)
+    entry = {"processable": True, "usability": "on"}
+    result = police._sort_status_entry(entry)
+    assert list(result.keys()) == ["usability", "processable"]
+
+
+def test_sort_status_entry_extra_keys_appended():
+    entry = {"extra": 42, "usability": "on", "processable": True}
+    result = police._sort_status_entry(entry)
+    # canonical keys come first, then unknown extras
+    assert list(result.keys()) == ["usability", "processable", "extra"]
+
+
+def test_sort_status_entry_psd_extra_keys_appended():
+    entry = {
+        "usability": "on",
+        "processable": True,
+        "psd": {
+            "status": {"low_aoe": "valid"},
+            "unknown_psd_key": True,
+            "is_bb_like": "low_aoe",
+        },
+    }
+    result = police._sort_status_entry(entry)
+    assert list(result["psd"].keys()) == ["is_bb_like", "status", "unknown_psd_key"]
+
+
+# ---------------------------------------------------------------------------
+# _sort_groupings_data
+# ---------------------------------------------------------------------------
+
+
+def test_sort_groupings_data_default_first():
+    data = {
+        "Z_detector": {"calgroup001a": {"p03": "r000..r001"}},
+        "default": {"calgroup001a": {"p03": "r000..r005"}},
+        "A_detector": {"calgroup001a": {"p03": "r000..r002"}},
+    }
+    result = police._sort_groupings_data(data)
+    keys = list(result.keys())
+    assert keys[0] == "default"
+    assert keys[1:] == sorted(["A_detector", "Z_detector"])
+
+
+def test_sort_groupings_data_groups_sorted():
+    data = {
+        "default": {
+            "calgroup002a": {"p06": "r000..r005"},
+            "calgroup001a": {"p03": "r000..r005"},
+        }
+    }
+    result = police._sort_groupings_data(data)
+    assert list(result["default"].keys()) == ["calgroup001a", "calgroup002a"]
+
+
+def test_sort_groupings_data_periods_sorted():
+    data = {
+        "default": {
+            "calgroup001a": {"p06": "r000..r005", "p03": "r000..r004"},
+        }
+    }
+    result = police._sort_groupings_data(data)
+    assert list(result["default"]["calgroup001a"].keys()) == ["p03", "p06"]
+
+
+def test_sort_groupings_data_run_list_sorted():
+    data = {
+        "default": {
+            "calgroup001a": {"p09": ["r003", "r001", "r005"]},
+        }
+    }
+    result = police._sort_groupings_data(data)
+    assert result["default"]["calgroup001a"]["p09"] == ["r001", "r003", "r005"]
+
+
+def test_sort_groupings_data_run_range_unchanged():
+    data = {"default": {"calgroup001a": {"p03": "r000..r005"}}}
+    result = police._sort_groupings_data(data)
+    assert result["default"]["calgroup001a"]["p03"] == "r000..r005"
+
+
+# ---------------------------------------------------------------------------
+# _fix_groupings_file
+# ---------------------------------------------------------------------------
+
+_SORTED_GROUPINGS = textwrap.dedent("""\
+    default:
+      calgroup001a:
+        p03: r000..r005
+      calgroup002a:
+        p06: r000..r005
+    B00002A:
+      calgroup001a:
+        p03: r000..r003
+    V08682A:
+      calgroup002a:
+        p06: r001..r005
+""")
+
+_UNSORTED_GROUPINGS = textwrap.dedent("""\
+    default:
+      calgroup002a:
+        p06: r000..r005
+      calgroup001a:
+        p03: r000..r005
+    V08682A:
+      calgroup002a:
+        p06: r001..r005
+    B00002A:
+      calgroup001a:
+        p03: r000..r003
+""")
+
+
+def test_fix_groupings_file_already_sorted(tmp_path):
+    f = _write(tmp_path, "cal_groupings.yaml", _SORTED_GROUPINGS)
+    assert not police._fix_groupings_file(f)
+    assert Path(f).read_text() == _SORTED_GROUPINGS
+
+
+def test_fix_groupings_file_unsorted_returns_true(tmp_path):
+    f = _write(tmp_path, "cal_groupings.yaml", _UNSORTED_GROUPINGS)
+    assert police._fix_groupings_file(f)
+
+
+def test_fix_groupings_file_result_passes_validation(tmp_path):
+    f = _write(tmp_path, "cal_groupings.yaml", _UNSORTED_GROUPINGS)
+    police._fix_groupings_file(f)
+    assert police._validate_groupings_file(f, "calgroup", verbose=False)
+
+
+def test_fix_groupings_file_data_preserved(tmp_path):
+    f = _write(tmp_path, "cal_groupings.yaml", _UNSORTED_GROUPINGS)
+    police._fix_groupings_file(f)
+    fixed = yaml.safe_load(Path(f).read_text())
+    original = yaml.safe_load(_UNSORTED_GROUPINGS)
+    assert fixed == original
+
+
+# ---------------------------------------------------------------------------
+# _fix_status_files
+# ---------------------------------------------------------------------------
+
+_SORTED_STATUS = {
+    "V02160A": {
+        "reason": "",
+        "usability": "on",
+        "processable": True,
+        "psd": {"is_bb_like": "low_aoe", "status": {"low_aoe": "valid"}},
+    }
+}
+
+_UNSORTED_STATUS = {
+    "V02160A": {
+        "processable": True,
+        "usability": "on",
+        "reason": "",
+        "psd": {"status": {"low_aoe": "valid"}, "is_bb_like": "low_aoe"},
+    }
+}
+
+
+def _write_status_dir(tmp_path: Path, files: dict[str, dict]) -> Path:
+    """Write a mock status directory with a validity.yaml and the given data files."""
+    (tmp_path / "validity.yaml").write_text(
+        "- valid_from: '20240101T000000Z'\n  apply: []\n"
+    )
+    for name, data in files.items():
+        with (tmp_path / name).open("w") as fh:
+            yaml.dump(data, fh, default_flow_style=False, sort_keys=False)
+    return tmp_path / "validity.yaml"
+
+
+def test_fix_status_files_already_sorted(tmp_path):
+    validity = _write_status_dir(tmp_path, {"status.yaml": _SORTED_STATUS})
+    assert not police._fix_status_files(str(validity))
+
+
+def test_fix_status_files_unsorted_returns_true(tmp_path):
+    validity = _write_status_dir(tmp_path, {"status.yaml": _UNSORTED_STATUS})
+    assert police._fix_status_files(str(validity))
+
+
+def test_fix_status_files_key_order_after_fix(tmp_path):
+    validity = _write_status_dir(tmp_path, {"status.yaml": _UNSORTED_STATUS})
+    police._fix_status_files(str(validity))
+    fixed = yaml.safe_load((tmp_path / "status.yaml").read_text())
+    assert list(fixed["V02160A"].keys()) == [
+        "reason",
+        "usability",
+        "processable",
+        "psd",
+    ]
+    assert list(fixed["V02160A"]["psd"].keys()) == ["is_bb_like", "status"]
+
+
+def test_fix_status_files_data_preserved(tmp_path):
+    validity = _write_status_dir(tmp_path, {"status.yaml": _UNSORTED_STATUS})
+    police._fix_status_files(str(validity))
+    fixed = yaml.safe_load((tmp_path / "status.yaml").read_text())
+    # values must be identical to original, only key order changes
+    assert fixed == yaml.safe_load(yaml.dump(_UNSORTED_STATUS))
+
+
+def test_fix_status_files_skips_validity_yaml(tmp_path):
+    # validity.yaml itself must never be touched
+    validity = _write_status_dir(tmp_path, {})
+    original_validity = validity.read_text()
+    police._fix_status_files(str(validity))
+    assert validity.read_text() == original_validity
+
+
+def test_fix_status_files_multiple_files(tmp_path):
+    validity = _write_status_dir(
+        tmp_path,
+        {
+            "a.yaml": _UNSORTED_STATUS,
+            "b.yaml": _SORTED_STATUS,
+        },
+    )
+    assert police._fix_status_files(str(validity))
+    fixed_a = yaml.safe_load((tmp_path / "a.yaml").read_text())
+    # a.yaml was fixed
+    assert list(fixed_a["V02160A"].keys()) == [
+        "reason",
+        "usability",
+        "processable",
+        "psd",
+    ]
+    # b.yaml was already sorted — data unchanged
+    fixed_b = yaml.safe_load((tmp_path / "b.yaml").read_text())
+    assert fixed_b == _SORTED_STATUS

--- a/tests/test_police.py
+++ b/tests/test_police.py
@@ -308,7 +308,7 @@ def test_chmap_key_name_mismatch_fails():
 
 
 def _write_status_files(tmp_path: Path, status_content: str) -> Path:
-    """Create a minimal status validity file and data file in *tmp_path*."""
+    """Create a minimal status validity file and data file in ``tmp_path``."""
     validity = textwrap.dedent("""\
         - valid_from: "20230101T000000Z"
           apply:

--- a/tests/test_police.py
+++ b/tests/test_police.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import sys
 import textwrap
 from copy import deepcopy
 from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from legendmeta import police
 
@@ -272,3 +276,102 @@ def test_groupings_overridden_run_not_present_passes(tmp_path):
     # p09/r005 is overridden but p09 doesn't appear in the file at all
     overridden = {("p09", "r005")}
     assert police._check_cal_override_runs(f, overridden, verbose=False)
+
+
+# ---------------------------------------------------------------------------
+# _check_chmap_key_name — channel map key vs name field
+# ---------------------------------------------------------------------------
+
+
+def test_chmap_key_name_absent_passes():
+    """Entry without a 'name' field is always valid."""
+    assert police._check_chmap_key_name("V01234A", {"system": "geds"})
+
+
+def test_chmap_key_name_match_passes():
+    """Entry whose 'name' matches the key is valid."""
+    assert police._check_chmap_key_name(
+        "V01234A", {"name": "V01234A", "system": "geds"}
+    )
+
+
+def test_chmap_key_name_mismatch_fails():
+    """Entry whose 'name' differs from the key is invalid."""
+    assert not police._check_chmap_key_name(
+        "V01234A", {"name": "V99999Z", "system": "geds"}, verbose=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# validate_statuses — status key membership in channel map
+# ---------------------------------------------------------------------------
+
+
+def _write_status_files(tmp_path: Path, status_content: str) -> Path:
+    """Create a minimal status validity file and data file in *tmp_path*."""
+    validity = textwrap.dedent("""\
+        - valid_from: "20230101T000000Z"
+          apply:
+            - status.yaml
+    """)
+    (tmp_path / "validity.yaml").write_text(validity)
+    (tmp_path / "status.yaml").write_text(status_content)
+    return tmp_path / "validity.yaml"
+
+
+def test_validate_statuses_key_not_in_chmap(tmp_path, monkeypatch):
+    """validate_statuses fails when a status key is absent from the channel map."""
+    # "ch_missing" is not a GE/SiPM channel, so only the chmap check fires.
+    validity_file = _write_status_files(
+        tmp_path,
+        textwrap.dedent("""\
+            ch_missing:
+              flag: true
+        """),
+    )
+
+    mock_meta = MagicMock()
+    mock_meta.hardware.configuration.channelmaps.on.return_value = {}
+
+    monkeypatch.setattr(sys, "argv", ["validate-statuses", str(validity_file)])
+    with (
+        patch("legendmeta.police.LegendMetadata", return_value=mock_meta),
+        pytest.raises(SystemExit),
+    ):
+        police.validate_statuses()
+
+
+def test_validate_statuses_key_in_chmap(tmp_path, monkeypatch):
+    """validate_statuses passes when every status key is present in the channel map."""
+    validity_file = _write_status_files(
+        tmp_path,
+        textwrap.dedent("""\
+            ch_present:
+              flag: true
+        """),
+    )
+
+    mock_meta = MagicMock()
+    mock_meta.hardware.configuration.channelmaps.on.return_value = {"ch_present": {}}
+
+    monkeypatch.setattr(sys, "argv", ["validate-statuses", str(validity_file)])
+    with patch("legendmeta.police.LegendMetadata", return_value=mock_meta):
+        police.validate_statuses()  # should not raise
+
+
+def test_validate_statuses_chmap_unavailable_skips_check(tmp_path, monkeypatch):
+    """When the channel map cannot be loaded the membership check is silently skipped."""
+    validity_file = _write_status_files(
+        tmp_path,
+        textwrap.dedent("""\
+            ch_anything:
+              flag: true
+        """),
+    )
+
+    mock_meta = MagicMock()
+    mock_meta.hardware.configuration.channelmaps.on.side_effect = Exception("no repo")
+
+    monkeypatch.setattr(sys, "argv", ["validate-statuses", str(validity_file)])
+    with patch("legendmeta.police.LegendMetadata", return_value=mock_meta):
+        police.validate_statuses()  # chmap unavailable → no error


### PR DESCRIPTION
Two new validation behaviors in `police.py` (key/name consistency in channel maps; status key membership in channel map) lacked unit tests.

### Changes

- **`_check_chmap_key_name` helper** (`police.py`): extracted the inline `name`-vs-key check from `validate_legend_channel_map` into a standalone testable function.
- add sorting functions for grouping files and status files

- **Unit tests** (`test_police.py`):
  - `_check_chmap_key_name`: name absent → pass; name matches key → pass; name mismatches key → fail
  - `validate_statuses` chmap membership: key missing → `sys.exit(1)`; key present → pass; chmap load failure → check silently skipped (uses mocked `LegendMetadata`)

```python
# mismatch detection
assert not police._check_chmap_key_name("V01234A", {"name": "V99999Z", "system": "geds"}, verbose=False)

# status key absent from channel map triggers failure
mock_meta.hardware.configuration.channelmaps.on.return_value = {}
with patch("legendmeta.police.LegendMetadata", return_value=mock_meta), pytest.raises(SystemExit):
    police.validate_statuses()
```