### PR TITLE
Add detection of unreferenced data files in validity.yaml

### DIFF
--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -296,7 +296,7 @@ def _find_unreferenced_files(
         # skip files in subdirectories that have their own validity.yaml
         skip = False
         for p in rel.parents:
-            if p != Path(".") and (parent / p / "validity.yaml").exists():
+            if p != Path() and (parent / p / "validity.yaml").exists():
                 skip = True
                 break
         if skip:

--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -260,6 +260,59 @@ def len_nested(d: dict) -> int:
     return count
 
 
+def _find_unreferenced_files(
+    validity_file: str, referenced: set[str], verbose: bool = True
+) -> list[str]:
+    """Find YAML/JSON data files not referenced in the validity file.
+
+    Parameters
+    ----------
+    validity_file
+        Path to the validity YAML file.
+    referenced
+        Set of file paths (relative to the validity file's directory) that
+        are referenced in the validity file's ``apply`` entries.
+    verbose
+        If True, print error messages.
+
+    Returns
+    -------
+    list[str]
+        Relative paths of unreferenced data files.
+    """
+    parent = Path(validity_file).parent
+    unreferenced = []
+
+    for data_file in sorted(parent.rglob("*")):
+        if not data_file.is_file():
+            continue
+        if data_file.suffix not in (".yaml", ".json"):
+            continue
+        if data_file.name == "validity.yaml":
+            continue
+
+        rel = data_file.relative_to(parent)
+
+        # skip files in subdirectories that have their own validity.yaml
+        skip = False
+        for p in rel.parents:
+            if p != Path(".") and (parent / p / "validity.yaml").exists():
+                skip = True
+                break
+        if skip:
+            continue
+
+        rel_str = str(rel)
+        if rel_str not in referenced:
+            unreferenced.append(rel_str)
+            if verbose:
+                print(  # noqa: T201
+                    f" ERROR : {rel_str} not referenced in {validity_file}"
+                )
+
+    return unreferenced
+
+
 def validate_validity():
     parser = argparse.ArgumentParser(
         prog="validate-validity", description="Validate LEGEND validity files"
@@ -273,14 +326,21 @@ def validate_validity():
         Catalog.read_from(file)
         # check files in validity exist
         valid_dic = Props.read_from(str(file))
+        referenced_files = set()
         for dic in valid_dic:
             for f in dic["apply"]:
+                referenced_files.add(f)
                 full_path = Path(file).parent / f
                 if full_path.exists() is False:
                     print(  # noqa: T201
                         f" ERROR : no file {full_path}"
                     )
                     valid = False
+
+        # check for files not referenced in validity
+        if _find_unreferenced_files(file, referenced_files):
+            valid = False
+
     if not valid:
         sys.exit(1)
 

--- a/tests/test_police.py
+++ b/tests/test_police.py
@@ -684,3 +684,142 @@ def test_fix_status_files_multiple_files(tmp_path):
     # b.yaml was already sorted — data unchanged
     fixed_b = yaml.safe_load((tmp_path / "b.yaml").read_text())
     assert fixed_b == _SORTED_STATUS
+
+
+# ---------------------------------------------------------------------------
+# _find_unreferenced_files
+# ---------------------------------------------------------------------------
+
+
+def _write_validity(tmp_path: Path, entries: list[dict]) -> Path:
+    """Write a validity.yaml file and return its path."""
+    p = tmp_path / "validity.yaml"
+    with p.open("w") as fh:
+        yaml.dump(entries, fh, default_flow_style=False)
+    return p
+
+
+def test_find_unreferenced_files_all_referenced(tmp_path):
+    """No unreferenced files when every data file is in apply."""
+    (tmp_path / "a.yaml").write_text("key: value\n")
+    (tmp_path / "b.json").write_text("{}\n")
+    _write_validity(
+        tmp_path,
+        [{"valid_from": "20230101T000000Z", "apply": ["a.yaml", "b.json"]}],
+    )
+    referenced = {"a.yaml", "b.json"}
+    result = police._find_unreferenced_files(
+        str(tmp_path / "validity.yaml"), referenced, verbose=False
+    )
+    assert result == []
+
+
+def test_find_unreferenced_files_detects_orphan(tmp_path):
+    """An unreferenced YAML file is detected."""
+    (tmp_path / "a.yaml").write_text("key: value\n")
+    (tmp_path / "orphan.yaml").write_text("key: value\n")
+    _write_validity(
+        tmp_path,
+        [{"valid_from": "20230101T000000Z", "apply": ["a.yaml"]}],
+    )
+    referenced = {"a.yaml"}
+    result = police._find_unreferenced_files(
+        str(tmp_path / "validity.yaml"), referenced, verbose=False
+    )
+    assert "orphan.yaml" in result
+
+
+def test_find_unreferenced_files_detects_orphan_json(tmp_path):
+    """An unreferenced JSON file is detected."""
+    (tmp_path / "a.yaml").write_text("key: value\n")
+    (tmp_path / "orphan.json").write_text("{}\n")
+    _write_validity(
+        tmp_path,
+        [{"valid_from": "20230101T000000Z", "apply": ["a.yaml"]}],
+    )
+    referenced = {"a.yaml"}
+    result = police._find_unreferenced_files(
+        str(tmp_path / "validity.yaml"), referenced, verbose=False
+    )
+    assert "orphan.json" in result
+
+
+def test_find_unreferenced_files_ignores_validity_yaml(tmp_path):
+    """validity.yaml itself is never flagged."""
+    _write_validity(
+        tmp_path,
+        [{"valid_from": "20230101T000000Z", "apply": []}],
+    )
+    referenced = set()
+    result = police._find_unreferenced_files(
+        str(tmp_path / "validity.yaml"), referenced, verbose=False
+    )
+    assert "validity.yaml" not in result
+    assert result == []
+
+
+def test_find_unreferenced_files_ignores_non_yaml_json(tmp_path):
+    """Non-YAML/JSON files are not flagged."""
+    (tmp_path / "readme.md").write_text("# hello\n")
+    (tmp_path / "data.txt").write_text("some data\n")
+    _write_validity(
+        tmp_path,
+        [{"valid_from": "20230101T000000Z", "apply": []}],
+    )
+    referenced = set()
+    result = police._find_unreferenced_files(
+        str(tmp_path / "validity.yaml"), referenced, verbose=False
+    )
+    assert result == []
+
+
+def test_find_unreferenced_files_skips_subdir_with_own_validity(tmp_path):
+    """Files in subdirectories with their own validity.yaml are skipped."""
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    (subdir / "validity.yaml").write_text("[]\n")
+    (subdir / "managed_elsewhere.yaml").write_text("key: value\n")
+
+    _write_validity(
+        tmp_path,
+        [{"valid_from": "20230101T000000Z", "apply": []}],
+    )
+    referenced = set()
+    result = police._find_unreferenced_files(
+        str(tmp_path / "validity.yaml"), referenced, verbose=False
+    )
+    assert result == []
+
+
+def test_find_unreferenced_files_includes_subdir_without_validity(tmp_path):
+    """Files in subdirectories without their own validity.yaml are checked."""
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    (subdir / "orphan.yaml").write_text("key: value\n")
+
+    _write_validity(
+        tmp_path,
+        [{"valid_from": "20230101T000000Z", "apply": []}],
+    )
+    referenced = set()
+    result = police._find_unreferenced_files(
+        str(tmp_path / "validity.yaml"), referenced, verbose=False
+    )
+    assert any("orphan.yaml" in r for r in result)
+
+
+def test_find_unreferenced_files_subdir_file_referenced(tmp_path):
+    """A file in a subdirectory that IS referenced passes."""
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    (subdir / "data.yaml").write_text("key: value\n")
+
+    _write_validity(
+        tmp_path,
+        [{"valid_from": "20230101T000000Z", "apply": ["sub/data.yaml"]}],
+    )
+    referenced = {"sub/data.yaml"}
+    result = police._find_unreferenced_files(
+        str(tmp_path / "validity.yaml"), referenced, verbose=False
+    )
+    assert result == []


### PR DESCRIPTION
## Summary
This PR adds functionality to detect YAML and JSON data files that exist in the file system but are not referenced in the `validity.yaml` configuration file. This helps identify orphaned or forgotten data files that should either be added to the validity configuration or removed.

## Key Changes
- **New function `_find_unreferenced_files()`**: Scans the directory containing a validity file for all `.yaml` and `.json` files and identifies those not listed in the `apply` entries
  - Recursively searches subdirectories
  - Skips subdirectories that have their own `validity.yaml` file (allowing nested validity configurations)
  - Ignores the `validity.yaml` file itself and non-data files
  - Returns relative paths of unreferenced files with optional verbose output

- **Enhanced `validate_validity()` command**: Now tracks all referenced files and calls `_find_unreferenced_files()` to detect orphans
  - Collects all files mentioned in `apply` entries
  - Fails validation if unreferenced files are found

- **Comprehensive test coverage**: Added 8 new test cases covering:
  - All files properly referenced
  - Detection of orphaned YAML and JSON files
  - Proper handling of `validity.yaml` itself
  - Filtering of non-data files
  - Subdirectory handling with and without nested validity files
  - Referenced files in subdirectories

## Implementation Details
- Uses `Path.rglob()` for recursive file discovery
- Checks parent directories for nested `validity.yaml` files to respect configuration boundaries
- Maintains backward compatibility with existing validation logic

https://claude.ai/code/session_01LWMyhtA4bBdKhSo7EyBA1C