### PR TITLE
channelmap returns readonly AttrsDict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "packaging",
-    "dbetto>=1.2.2",
+    "dbetto>=1.3.5",
     "GitPython",
     "pandas",
     "pyyaml",

--- a/src/legendmeta/legendmetadata.py
+++ b/src/legendmeta/legendmetadata.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from datetime import datetime
 
 from dbetto import AttrsDict
@@ -103,8 +104,8 @@ class LegendMetadata(MetadataRepository):
         if on is None:
             on = datetime.now()
 
-        chmap = self.hardware.configuration.channelmaps.on(
-            on, pattern=None, system=system
+        chmap = deepcopy(
+            self.hardware.configuration.channelmaps.on(on, pattern=None, system=system)
         )
 
         # get analysis metadata
@@ -139,4 +140,5 @@ class LegendMetadata(MetadataRepository):
                 msg = f"Could not find detector '{det}' in dataprod.config database"
                 log.debug(msg)
 
+        chmap.__readonly__ = True
         return chmap

--- a/tests/test_lmeta.py
+++ b/tests/test_lmeta.py
@@ -112,6 +112,7 @@ def test_channelmap(metadb):
     metadb.scan()
     assert isinstance(metadb, LegendMetadata)
     assert isinstance(metadb.channelmap(date), AttrsDict)
+    assert metadb.channelmap(date).__readonly__
     channel = metadb.channelmap(on=date).V02160A
     assert isinstance(channel, AttrsDict)
     assert "geometry" in channel


### PR DESCRIPTION
This is required to work with https://github.com/gipert/dbetto/pull/48 (which is a prerequisite for this).

Correctly build up channelmap by deepcopying the first item read since on reads it as read-only; also returns the channelmap as read-only.