### PR TITLE
Add tabular views over metadata for join-friendly queries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "psycopg2-binary<=2.9.9; python_version<'3.10' and platform_system=='Darwin'",
     "psycopg2-binary; python_version>='3.10' or platform_system!='Darwin'",
     "sqlalchemy>=2",
+    "polars>=1.40",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ ignore = [
   "PLR2004",  # Magic value used in comparison
   "ISC001",   # Conflicts with formatter
   "PT011",    # too picky pytest.raises() complaint
+  "PLC0415",  # `import` should be at the top-level of a file
 ]
 isort.required-imports = ["from __future__ import annotations"]
 

--- a/src/legendmeta/legendmetadata.py
+++ b/src/legendmeta/legendmetadata.py
@@ -148,4 +148,5 @@ class LegendMetadata(MetadataRepository):
     def tables(self):
         """Tabular views over the metadata. See :class:`legendmeta.tables.Tables`."""
         from .tables import Tables
+
         return Tables(self)

--- a/src/legendmeta/legendmetadata.py
+++ b/src/legendmeta/legendmetadata.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from datetime import datetime
-from functools import cached_property
 
 from dbetto import AttrsDict
 from packaging.version import Version
@@ -143,10 +142,3 @@ class LegendMetadata(MetadataRepository):
 
         chmap.__readonly__ = True
         return chmap
-
-    @cached_property
-    def tables(self):
-        """Tabular views over the metadata. See :class:`legendmeta.tables.Tables`."""
-        from .tables import Tables
-
-        return Tables(self)

--- a/src/legendmeta/legendmetadata.py
+++ b/src/legendmeta/legendmetadata.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from datetime import datetime
+from functools import cached_property
 
 from dbetto import AttrsDict
 from packaging.version import Version
@@ -142,3 +143,9 @@ class LegendMetadata(MetadataRepository):
 
         chmap.__readonly__ = True
         return chmap
+
+    @cached_property
+    def tables(self):
+        """Tabular views over the metadata. See :class:`legendmeta.tables.Tables`."""
+        from .tables import Tables
+        return Tables(self)

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -1,5 +1,7 @@
 from functools import cached_property
+
 import polars as pl
+from dbetto import AttrsDict
 
 def _resolve_runinfo(lmeta):
     """Get runinfo dict, handling metadata layout differences."""
@@ -65,11 +67,8 @@ class Tables:
 
     @cached_property
     def statuses(self) -> pl.DataFrame:
-        """Per-(period, run, datatype, detector) analysis status DataFrame.
+        """Per-(period, run, datatype, detector) analysis status DataFrame."""
 
-        Combines metadata-version differences in the statuses path internally
-        via :func:`_resolve_statuses_on`.
-        """
         statuses_on = _resolve_statuses_on(self._lmeta)
         dfs = []
         for row in self.runinfo.iter_rows(named=True):
@@ -86,26 +85,24 @@ class Tables:
         return pl.concat(dfs, how="diagonal_relaxed")
 
     @cached_property
-    def channelmaps(self) -> dict[str, pl.DataFrame]:
-        """Per-system channelmap DataFrames, keyed by system name."""
+    def channelmaps(self) -> AttrsDict:
+        """Per-system channelmap DataFrames, accessible by attribute or key."""
+
         period_ts = self.runinfo.group_by("period").agg(pl.col("start_key").min())
 
         by_system: dict[str, list[dict]] = {}
         for row in period_ts.iter_rows(named=True):
-            period = row["period"]
             chmap = self._lmeta.hardware.configuration.channelmaps.on(row["start_key"])
             for name, e in chmap.items():
                 rawid = e.get("daq", {}).get("rawid")
                 by_system.setdefault(e["system"], []).append(
-                    {**e, "name": name, "period": period, "rawid": rawid}
+                    {**e, "name": name, "period": row["period"], "rawid": rawid}
                 )
 
-        runs = self.runinfo.select("period", "run").unique()
-        return {
+        return AttrsDict({
             sys: pl.from_dicts(entries, strict=False, infer_schema_length=None)
-                  .join(runs, on="period", how="inner")
             for sys, entries in by_system.items()
-        }
+        })
 
     @cached_property
     def crystals(self) -> pl.DataFrame:

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -14,6 +14,7 @@ def _resolve_runinfo(lmeta):
     except (AttributeError, FileNotFoundError):
         return lmeta.dataprod.runinfo
 
+
 def _resolve_statuses_on(lmeta):
     """Return a callable ts -> statuses dict, also handling metadata layout
     differences."""
@@ -22,6 +23,7 @@ def _resolve_statuses_on(lmeta):
         return lmeta.datasets.statuses.on
     except (AttributeError, FileNotFoundError):
         return lambda ts: lmeta.dataprod.config.on(ts).analysis
+
 
 def _textdb_to_df(db) -> pl.DataFrame:
     """Materialize a TextDB directory of records as a Polars DataFrame.
@@ -44,6 +46,7 @@ def _textdb_to_df(db) -> pl.DataFrame:
 
     return pl.from_dicts(file_items, strict=False, infer_schema_length=None)
 
+
 def _stringify_keys(obj):
     """Recursively coerce dict keys to strings.
 
@@ -54,6 +57,7 @@ def _stringify_keys(obj):
     if isinstance(obj, dict):
         return {str(k): _stringify_keys(v) for k, v in obj.items()}
     return obj
+
 
 class Tables:
     """Polars DataFrame views over LEGEND metadata.
@@ -72,17 +76,21 @@ class Tables:
     @cached_property
     def runinfo(self) -> pl.DataFrame:
         _runinfo = _resolve_runinfo(self._lmeta)
-        return pl.from_dicts([
-            {
-                "period": int(p.removeprefix("p")),
-                "run": int(r.removeprefix("r")),
-                "datatype": dt,
-                **_stringify_keys(info),  # acs runs, etc, have int-keyed sub-dicts
-            }
-            for p, runs in _runinfo.items()
-            for r, datatypes in runs.items()
-            for dt, info in datatypes.items()
-        ], strict=False, infer_schema_length=None)
+        return pl.from_dicts(
+            [
+                {
+                    "period": int(p.removeprefix("p")),
+                    "run": int(r.removeprefix("r")),
+                    "datatype": dt,
+                    **_stringify_keys(info),  # acs runs, etc, have int-keyed sub-dicts
+                }
+                for p, runs in _runinfo.items()
+                for r, datatypes in runs.items()
+                for dt, info in datatypes.items()
+            ],
+            strict=False,
+            infer_schema_length=None,
+        )
 
     @cached_property
     def statuses(self) -> pl.DataFrame:
@@ -94,13 +102,16 @@ class Tables:
             st = statuses_on(row["start_key"])
             df = pl.from_dicts(
                 [{"name": k, **_stringify_keys(v)} for k, v in st.items()],
-                strict=False, infer_schema_length=None,
+                strict=False,
+                infer_schema_length=None,
             )
-            dfs.append(df.with_columns(
-                period=pl.lit(row["period"]),
-                run=pl.lit(row["run"]),
-                datatype=pl.lit(row["datatype"]),
-            ))
+            dfs.append(
+                df.with_columns(
+                    period=pl.lit(row["period"]),
+                    run=pl.lit(row["run"]),
+                    datatype=pl.lit(row["datatype"]),
+                )
+            )
         return pl.concat(dfs, how="diagonal_relaxed")
 
     @cached_property
@@ -127,10 +138,12 @@ class Tables:
                     {**e, "name": name, "period": period, "rawid": rawid}
                 )
 
-        return AttrsDict({
-            sys: pl.from_dicts(entries, strict=False, infer_schema_length=None)
-            for sys, entries in by_system.items()
-        })
+        return AttrsDict(
+            {
+                sys: pl.from_dicts(entries, strict=False, infer_schema_length=None)
+                for sys, entries in by_system.items()
+            }
+        )
 
     @cached_property
     def crystals(self) -> pl.DataFrame:

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -67,7 +67,13 @@ class Tables:
     ``statuses``, ``channelmaps``) are concatenated across all known
     periods/runs.
 
-    Accessed via ``LegendMetadata.tables``.
+    Examples
+    --------
+    >>> from legendmeta import LegendMetadata
+    >>> from legendmeta.tables import Tables
+    >>> lmeta = LegendMetadata()
+    >>> tables = Tables(lmeta)
+    >>> tables.runinfo
     """
 
     def __init__(self, lmeta):
@@ -116,27 +122,33 @@ class Tables:
 
     @cached_property
     def channelmaps(self) -> AttrsDict:
-        """Per-system channelmap DataFrames, accessible by attribute or key."""
+        """Per-system channelmap DataFrames, accessible by attribute or key.
 
-        # Within a period, channelmap is invariant by convention.
-        # Sample at each period's first run; do NOT sample per-run.
-        period_ts = self.runinfo.group_by("period").agg(pl.col("start_key").min())
-
+        Channel maps are NOT guaranteed constant within a period (e.g. in p18
+        the SiPM DAQ mapping changed between the cal and phy runs of r000), so
+        rows are keyed on ``(period, run, datatype)`` — one channel map per
+        ``runinfo`` row, resolved at that row's ``start_key``, exactly like
+        :attr:`statuses`.
+        """
         by_system: dict[str, list[dict]] = {}
-        for row in period_ts.iter_rows(named=True):
-            period = row["period"]
+        for row in self.runinfo.iter_rows(named=True):
             chmap = self._lmeta.hardware.configuration.channelmaps.on(row["start_key"])
             for name, e in chmap.items():
                 rawid = e.get("daq", {}).get("rawid")
                 if rawid is None:
                     msg = (
-                        f"missing rawid for {name} in period {period}: "
-                        f"daq={e.get('daq')!r}"
+                        f"missing rawid for {name} in period {row['period']} "
+                        f"run {row['run']} ({row['datatype']}): daq={e.get('daq')!r}"
                     )
                     raise ValueError(msg)
-                by_system.setdefault(e["system"], []).append(
-                    {**e, "name": name, "period": period, "rawid": rawid}
-                )
+                by_system.setdefault(e["system"], []).append({
+                    **e,
+                    "name": name,
+                    "period": row["period"],
+                    "run": row["run"],
+                    "datatype": row["datatype"],
+                    "rawid": rawid,
+                })
 
         return AttrsDict(
             {

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -24,14 +24,25 @@ def _resolve_statuses_on(lmeta):
         return lambda ts: lmeta.dataprod.config.on(ts).analysis
 
 def _textdb_to_df(db) -> pl.DataFrame:
-    """Materialize a TextDB directory of JSON records as a Polars DataFrame.
+    """Materialize a TextDB directory of records as a Polars DataFrame.
 
-    Sub-directories (TextDB entries) are skipped — only file records are included.
+    Nested sub-directories are skipped (with warning) — their schema is
+    unknown so it's unclear how to merge those with the top-level table.
     """
-    return pl.from_dicts(
-        [v for _, v in db.items() if not isinstance(v, TextDB)],
-        strict=False, infer_schema_length=None,
-    )
+    file_items, dir_names = [], []
+    for k, v in db.items():
+        if isinstance(v, TextDB):
+            dir_names.append(k)
+        else:
+            file_items.append(v)
+
+    if dir_names:
+        warnings.warn(
+            f"_textdb_to_df: skipping {len(dir_names)} sub-directories: {dir_names}",
+            stacklevel=2,
+        )
+
+    return pl.from_dicts(file_items, strict=False, infer_schema_length=None)
 
 def _stringify_keys(obj):
     """Recursively coerce dict keys to strings.

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -96,6 +96,8 @@ class Tables:
     def channelmaps(self) -> AttrsDict:
         """Per-system channelmap DataFrames, accessible by attribute or key."""
 
+        # Within a period, channelmap is invariant by convention.
+        # Sample at each period's first run; do NOT sample per-run.
         period_ts = self.runinfo.group_by("period").agg(pl.col("start_key").min())
 
         by_system: dict[str, list[dict]] = {}

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -141,14 +141,16 @@ class Tables:
                         f"run {row['run']} ({row['datatype']}): daq={e.get('daq')!r}"
                     )
                     raise ValueError(msg)
-                by_system.setdefault(e["system"], []).append({
-                    **e,
-                    "name": name,
-                    "period": row["period"],
-                    "run": row["run"],
-                    "datatype": row["datatype"],
-                    "rawid": rawid,
-                })
+                by_system.setdefault(e["system"], []).append(
+                    {
+                        **e,
+                        "name": name,
+                        "period": row["period"],
+                        "run": row["run"],
+                        "datatype": row["datatype"],
+                        "rawid": rawid,
+                    }
+                )
 
         return AttrsDict(
             {

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -20,9 +20,14 @@ def _resolve_statuses_on(lmeta):
         return lambda ts: lmeta.dataprod.config.on(ts).analysis
 
 def _textdb_to_df(db) -> pl.DataFrame:
-    """Materialize a TextDB directory of JSON records as a Polars DataFrame."""
+    """Materialize a TextDB directory of JSON records as a Polars DataFrame.
+
+    Sub-directories (TextDB entries) are skipped — only file records are included.
+    """
+    from dbetto import TextDB
     return pl.from_dicts(
-        [v for _, v in db.items()], strict=False, infer_schema_length=None
+        [v for _, v in db.items() if not isinstance(v, TextDB)],
+        strict=False, infer_schema_length=None,
     )
 
 def _stringify_keys(obj):
@@ -119,23 +124,3 @@ class Tables:
     @cached_property
     def fibers(self) -> pl.DataFrame:
         return _textdb_to_df(self._lmeta.hardware.detectors.lar.fibers)
-
-
-if __name__ == "__main__":
-
-    from legendmeta import LegendMetadata
-
-    lmeta = LegendMetadata('/global/cfs/cdirs/m2676/data/lngs/l200/public/prodenv/prod-blind/ref/latest/inputs')
-    runinfo = Tables(lmeta).runinfo
-    sts = Tables(lmeta).statuses
-    cms_geds = Tables(lmeta).channelmaps['geds']
-
-    lmeta2 = LegendMetadata()
-    runinfo2 = Tables(lmeta2).runinfo
-    sts2 = Tables(lmeta2).statuses
-    cms_geds2 = Tables(lmeta2).channelmaps['geds']
-
-    crystals = Tables(lmeta).crystals
-    diodes = Tables(lmeta).diodes
-    sipms = Tables(lmeta).sipms
-    fibers = Tables(lmeta).fibers

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
+import warnings
 from functools import cached_property
 
 import polars as pl
-from dbetto import AttrsDict
+from dbetto import AttrsDict, TextDB
+
 
 def _resolve_runinfo(lmeta):
     """Get runinfo dict, handling metadata layout differences."""
@@ -15,7 +19,7 @@ def _resolve_statuses_on(lmeta):
     differences."""
     try:
         _ = lmeta.datasets.statuses
-        return lambda ts: lmeta.datasets.statuses.on(ts)
+        return lmeta.datasets.statuses.on
     except (AttributeError, FileNotFoundError):
         return lambda ts: lmeta.dataprod.config.on(ts).analysis
 
@@ -24,7 +28,6 @@ def _textdb_to_df(db) -> pl.DataFrame:
 
     Sub-directories (TextDB entries) are skipped — only file records are included.
     """
-    from dbetto import TextDB
     return pl.from_dicts(
         [v for _, v in db.items() if not isinstance(v, TextDB)],
         strict=False, infer_schema_length=None,
@@ -97,11 +100,18 @@ class Tables:
 
         by_system: dict[str, list[dict]] = {}
         for row in period_ts.iter_rows(named=True):
+            period = row["period"]
             chmap = self._lmeta.hardware.configuration.channelmaps.on(row["start_key"])
             for name, e in chmap.items():
                 rawid = e.get("daq", {}).get("rawid")
+                if rawid is None:
+                    msg = (
+                        f"missing rawid for {name} in period {period}: "
+                        f"daq={e.get('daq')!r}"
+                    )
+                    raise ValueError(msg)
                 by_system.setdefault(e["system"], []).append(
-                    {**e, "name": name, "period": row["period"], "rawid": rawid}
+                    {**e, "name": name, "period": period, "rawid": rawid}
                 )
 
         return AttrsDict({

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -1,0 +1,144 @@
+from functools import cached_property
+import polars as pl
+
+def _resolve_runinfo(lmeta):
+    """Get runinfo dict, handling metadata layout differences."""
+    try:
+        return lmeta.datasets.runinfo
+    except (AttributeError, FileNotFoundError):
+        return lmeta.dataprod.runinfo
+
+def _resolve_statuses_on(lmeta):
+    """Return a callable ts -> statuses dict, also handling metadata layout
+    differences."""
+    try:
+        _ = lmeta.datasets.statuses
+        return lambda ts: lmeta.datasets.statuses.on(ts)
+    except (AttributeError, FileNotFoundError):
+        return lambda ts: lmeta.dataprod.config.on(ts).analysis
+
+def _textdb_to_df(db) -> pl.DataFrame:
+    """Materialize a TextDB directory of JSON records as a Polars DataFrame."""
+    return pl.from_dicts(
+        [v for _, v in db.items()], strict=False, infer_schema_length=None
+    )
+
+def _stringify_keys(obj):
+    """Recursively coerce dict keys to strings.
+
+    Required because Polars structs need string field names, but some metadata
+    fields legitimately use integer keys — e.g. ``acs`` runs carry a
+    ``sis_setups`` dict keyed by SIS number and then by source position.
+    """
+    if isinstance(obj, dict):
+        return {str(k): _stringify_keys(v) for k, v in obj.items()}
+    return obj
+
+class Tables:
+    """Polars DataFrame views over LEGEND metadata.
+
+    Materializes and caches the dict-of-dict metadata structures into tabular
+    form for SQL-like analysis. Time-dependent tables (``runinfo``,
+    ``statuses``, ``channelmaps``) are concatenated across all known
+    periods/runs.
+
+    Accessed via ``LegendMetadata.tables``.
+    """
+
+    def __init__(self, lmeta):
+        self._lmeta = lmeta
+
+    @cached_property
+    def runinfo(self) -> pl.DataFrame:
+        _runinfo = _resolve_runinfo(self._lmeta)
+        return pl.from_dicts([
+            {
+                "period": int(p.removeprefix("p")),
+                "run": int(r.removeprefix("r")),
+                "datatype": dt,
+                **_stringify_keys(info),  # acs runs, etc, have int-keyed sub-dicts
+            }
+            for p, runs in _runinfo.items()
+            for r, datatypes in runs.items()
+            for dt, info in datatypes.items()
+        ], strict=False, infer_schema_length=None)
+
+    @cached_property
+    def statuses(self) -> pl.DataFrame:
+        """Per-(period, run, datatype, detector) analysis status DataFrame.
+
+        Combines metadata-version differences in the statuses path internally
+        via :func:`_resolve_statuses_on`.
+        """
+        statuses_on = _resolve_statuses_on(self._lmeta)
+        dfs = []
+        for row in self.runinfo.iter_rows(named=True):
+            st = statuses_on(row["start_key"])
+            df = pl.from_dicts(
+                [{"name": k, **_stringify_keys(v)} for k, v in st.items()],
+                strict=False, infer_schema_length=None,
+            )
+            dfs.append(df.with_columns(
+                period=pl.lit(row["period"]),
+                run=pl.lit(row["run"]),
+                datatype=pl.lit(row["datatype"]),
+            ))
+        return pl.concat(dfs, how="diagonal_relaxed")
+
+    @cached_property
+    def channelmaps(self) -> dict[str, pl.DataFrame]:
+        """Per-system channelmap DataFrames, keyed by system name."""
+        period_ts = self.runinfo.group_by("period").agg(pl.col("start_key").min())
+
+        by_system: dict[str, list[dict]] = {}
+        for row in period_ts.iter_rows(named=True):
+            period = row["period"]
+            chmap = self._lmeta.hardware.configuration.channelmaps.on(row["start_key"])
+            for name, e in chmap.items():
+                rawid = e.get("daq", {}).get("rawid")
+                by_system.setdefault(e["system"], []).append(
+                    {**e, "name": name, "period": period, "rawid": rawid}
+                )
+
+        runs = self.runinfo.select("period", "run").unique()
+        return {
+            sys: pl.from_dicts(entries, strict=False, infer_schema_length=None)
+                  .join(runs, on="period", how="inner")
+            for sys, entries in by_system.items()
+        }
+
+    @cached_property
+    def crystals(self) -> pl.DataFrame:
+        return _textdb_to_df(self._lmeta.hardware.detectors.germanium.crystals)
+
+    @cached_property
+    def diodes(self) -> pl.DataFrame:
+        return _textdb_to_df(self._lmeta.hardware.detectors.germanium.diodes)
+
+    @cached_property
+    def sipms(self) -> pl.DataFrame:
+        return _textdb_to_df(self._lmeta.hardware.detectors.lar.sipms)
+
+    @cached_property
+    def fibers(self) -> pl.DataFrame:
+        return _textdb_to_df(self._lmeta.hardware.detectors.lar.fibers)
+
+
+if __name__ == "__main__":
+
+    from legendmeta import LegendMetadata
+
+    lmeta = LegendMetadata('/global/cfs/cdirs/m2676/data/lngs/l200/public/prodenv/prod-blind/ref/latest/inputs')
+    runinfo = Tables(lmeta).runinfo
+    sts = Tables(lmeta).statuses
+    cms_geds = Tables(lmeta).channelmaps['geds']
+
+    lmeta2 = LegendMetadata()
+    runinfo2 = Tables(lmeta2).runinfo
+    sts2 = Tables(lmeta2).statuses
+    cms_geds2 = Tables(lmeta2).channelmaps['geds']
+
+    crystals = Tables(lmeta).crystals
+    diodes = Tables(lmeta).diodes
+    sipms = Tables(lmeta).sipms
+    fibers = Tables(lmeta).fibers

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+import tempfile
+
+import polars as pl
+import pytest
+from dbetto import AttrsDict
+from git import GitCommandError
+
+from legendmeta import LegendMetadata
+
+pytestmark = [
+    pytest.mark.xfail(run=True, reason="requires access to legend-metadata"),
+    pytest.mark.needs_metadata,
+]
+
+tmpdir = tempfile.mkdtemp()
+
+
+@pytest.fixture
+def metadb():
+    if os.getenv("LEGEND_METADATA_TESTDIR") is not None:
+        mdata = LegendMetadata(os.getenv("LEGEND_METADATA_TESTDIR"), lazy=True)
+    else:
+        mdata = LegendMetadata(str(tmpdir), lazy=True)
+    mdata.checkout("main")
+    return mdata
+
+
+@pytest.fixture
+def metadb_v056():
+    """Metadata at v0.5.6 — uses dataprod.runinfo and dataprod.config fallback paths."""
+    if os.getenv("LEGEND_METADATA_TESTDIR") is not None:
+        mdata = LegendMetadata(os.getenv("LEGEND_METADATA_TESTDIR"), lazy=True)
+    else:
+        mdata = LegendMetadata(str(tmpdir), lazy=True)
+    try:
+        mdata.checkout("v0.5.6")
+    except GitCommandError:
+        pytest.skip("cannot checkout v0.5.6 (missing submodule history)")
+    return mdata
+
+
+def test_runinfo(metadb):
+    metadb.scan()
+    df = metadb.tables.runinfo
+    assert isinstance(df, pl.DataFrame)
+    assert len(df) > 0
+    assert {"period", "run", "datatype"}.issubset(df.columns)
+
+
+def test_statuses(metadb):
+    metadb.scan()
+    df = metadb.tables.statuses
+    assert isinstance(df, pl.DataFrame)
+    assert len(df) > 0
+    assert {"period", "run", "datatype", "name"}.issubset(df.columns)
+
+
+def test_channelmaps(metadb):
+    metadb.scan()
+    chmaps = metadb.tables.channelmaps
+    assert isinstance(chmaps, AttrsDict)
+    assert "geds" in chmaps
+    assert isinstance(chmaps.geds, pl.DataFrame)
+    assert chmaps.geds is chmaps["geds"]
+    assert {"name", "period", "rawid"}.issubset(chmaps.geds.columns)
+
+
+def test_detector_tables(metadb):
+    metadb.scan()
+    for name in ("crystals", "diodes", "sipms", "fibers"):
+        df = getattr(metadb.tables, name)
+        assert isinstance(df, pl.DataFrame)
+
+
+def test_tables_cached(metadb):
+    metadb.scan()
+    assert metadb.tables is metadb.tables
+    assert metadb.tables.runinfo is metadb.tables.runinfo
+
+
+def test_runinfo_v056(metadb_v056):
+    metadb_v056.scan()
+    df = metadb_v056.tables.runinfo
+    assert isinstance(df, pl.DataFrame)
+    assert len(df) > 0
+    assert {"period", "run", "datatype"}.issubset(df.columns)
+
+
+def test_statuses_v056(metadb_v056):
+    metadb_v056.scan()
+    df = metadb_v056.tables.statuses
+    assert isinstance(df, pl.DataFrame)
+    assert len(df) > 0
+    assert {"period", "run", "datatype", "name"}.issubset(df.columns)
+
+
+def test_channelmaps_v056(metadb_v056):
+    metadb_v056.scan()
+    chmaps = metadb_v056.tables.channelmaps
+    assert isinstance(chmaps, AttrsDict)
+    assert "geds" in chmaps
+    assert isinstance(chmaps.geds, pl.DataFrame)
+    assert {"name", "period", "rawid"}.issubset(chmaps.geds.columns)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -9,6 +9,7 @@ from dbetto import AttrsDict
 from git import GitCommandError
 
 from legendmeta import LegendMetadata
+from legendmeta.tables import Tables
 
 pytestmark = [
     pytest.mark.xfail(run=True, reason="requires access to legend-metadata"),
@@ -44,7 +45,7 @@ def metadb_v056():
 
 def test_runinfo(metadb):
     metadb.scan()
-    df = metadb.tables.runinfo
+    df = Tables(metadb).runinfo
     assert isinstance(df, pl.DataFrame)
     assert len(df) > 0
     assert {"period", "run", "datatype"}.issubset(df.columns)
@@ -52,7 +53,7 @@ def test_runinfo(metadb):
 
 def test_statuses(metadb):
     metadb.scan()
-    df = metadb.tables.statuses
+    df = Tables(metadb).statuses
     assert isinstance(df, pl.DataFrame)
     assert len(df) > 0
     assert {"period", "run", "datatype", "name"}.issubset(df.columns)
@@ -60,30 +61,50 @@ def test_statuses(metadb):
 
 def test_channelmaps(metadb):
     metadb.scan()
-    chmaps = metadb.tables.channelmaps
+    tables = Tables(metadb)
+    chmaps = tables.channelmaps
     assert isinstance(chmaps, AttrsDict)
     assert "geds" in chmaps
     assert isinstance(chmaps.geds, pl.DataFrame)
     assert chmaps.geds is chmaps["geds"]
-    assert {"name", "period", "rawid"}.issubset(chmaps.geds.columns)
+    assert {"name", "period", "run", "datatype", "rawid"}.issubset(chmaps.geds.columns)
+
+    # one channelmap per runinfo row: (period, run, datatype, name) is unique
+    keys = chmaps.geds.select("period", "run", "datatype", "name")
+    assert keys.is_duplicated().sum() == 0
+
+    # every runinfo row is covered by at least one system (not necessarily
+    # geds: e.g. p13 is SiPM-only commissioning and has no geds entries)
+    all_keys = pl.concat(
+        [df.select("period", "run", "datatype") for df in chmaps.values()]
+    ).unique()
+    runinfo_keys = tables.runinfo.select("period", "run", "datatype").unique()
+    covered = runinfo_keys.join(all_keys, on=["period", "run", "datatype"])
+    assert covered.height == runinfo_keys.height
 
 
 def test_detector_tables(metadb):
     metadb.scan()
-    for name in ("crystals", "diodes", "sipms", "fibers"):
-        df = getattr(metadb.tables, name)
+    tables = Tables(metadb)
+    for name in ("crystals", "sipms", "fibers"):
+        df = getattr(tables, name)
         assert isinstance(df, pl.DataFrame)
+
+    # diodes contains a "simulation" sub-directory, skipped with a warning
+    with pytest.warns(UserWarning, match="simulation"):
+        df = tables.diodes
+    assert isinstance(df, pl.DataFrame)
 
 
 def test_tables_cached(metadb):
     metadb.scan()
-    assert metadb.tables is metadb.tables
-    assert metadb.tables.runinfo is metadb.tables.runinfo
+    tables = Tables(metadb)
+    assert tables.runinfo is tables.runinfo
 
 
 def test_runinfo_v056(metadb_v056):
     metadb_v056.scan()
-    df = metadb_v056.tables.runinfo
+    df = Tables(metadb_v056).runinfo
     assert isinstance(df, pl.DataFrame)
     assert len(df) > 0
     assert {"period", "run", "datatype"}.issubset(df.columns)
@@ -91,7 +112,7 @@ def test_runinfo_v056(metadb_v056):
 
 def test_statuses_v056(metadb_v056):
     metadb_v056.scan()
-    df = metadb_v056.tables.statuses
+    df = Tables(metadb_v056).statuses
     assert isinstance(df, pl.DataFrame)
     assert len(df) > 0
     assert {"period", "run", "datatype", "name"}.issubset(df.columns)
@@ -99,8 +120,8 @@ def test_statuses_v056(metadb_v056):
 
 def test_channelmaps_v056(metadb_v056):
     metadb_v056.scan()
-    chmaps = metadb_v056.tables.channelmaps
+    chmaps = Tables(metadb_v056).channelmaps
     assert isinstance(chmaps, AttrsDict)
     assert "geds" in chmaps
     assert isinstance(chmaps.geds, pl.DataFrame)
-    assert {"name", "period", "rawid"}.issubset(chmaps.geds.columns)
+    assert {"name", "period", "run", "datatype", "rawid"}.issubset(chmaps.geds.columns)


### PR DESCRIPTION
## Motivation

This PR adds `LegendMetadata.tables`, a lazily-built collection of Polars DataFrames over the most commonly-queried metadata, alongside (not replacing) the existing dict-based API. The tabular views support operations that are awkward against nested dicts: filtering across detectors, joining metadata against event data, aggregating over runs.

## Examples

```python
In [1]: from legendmeta import LegendMetadata
   ...: import polars as pl
   ...:
   ...: lmeta = LegendMetadata()
   ...:

In [2]: # runinfo: one row per (period, run, datatype)
   ...: lmeta.tables.runinfo.filter(pl.col("period") == 10)
Out[2]:
shape: (30, 6)
┌────────┬─────┬──────────┬──────────────────┬───────────────┬────────────┐
│ period ┆ run ┆ datatype ┆ start_key        ┆ livetime_in_s ┆ sis_setups │
│ ---    ┆ --- ┆ ---      ┆ ---              ┆ ---           ┆ ---        │
│ i64    ┆ i64 ┆ str      ┆ str              ┆ f64           ┆ struct[1]  │
╞════════╪═════╪══════════╪══════════════════╪═══════════════╪════════════╡
│ 10     ┆ 0   ┆ cal      ┆ 20240226T104834Z ┆ null          ┆ null       │
│ 10     ┆ 0   ┆ fft      ┆ 20240226T164150Z ┆ null          ┆ null       │
│ 10     ┆ 0   ┆ phy      ┆ 20240226T164758Z ┆ 522140.0      ┆ null       │
│ 10     ┆ 0   ┆ pzc      ┆ 20240226T132022Z ┆ null          ┆ null       │
│ 10     ┆ 1   ┆ cal      ┆ 20240304T134049Z ┆ null          ┆ null       │
│ …      ┆ …   ┆ …        ┆ …                ┆ …             ┆ …          │
│ 10     ┆ 6   ┆ phy      ┆ 20240403T074857Z ┆ 265100.0      ┆ null       │
│ 10     ┆ 6   ┆ pzc      ┆ 20240402T224329Z ┆ null          ┆ null       │
│ 10     ┆ 7   ┆ cal      ┆ 20240406T103043Z ┆ null          ┆ null       │
│ 10     ┆ 7   ┆ fft      ┆ 20240406T171501Z ┆ null          ┆ null       │
│ 10     ┆ 7   ┆ pzc      ┆ 20240406T131550Z ┆ null          ┆ null       │
└────────┴─────┴──────────┴──────────────────┴───────────────┴────────────┘

In [3]: # statuses: per-detector analysis status across all runs
   ...: lmeta.tables.statuses.filter(pl.col("usability") == "on")
   ...:
Out[3]:
shape: (75_411, 10)
┌─────────┬─────────────────────────────────┬───────────┬─────────────┬───┬────────┬─────┬──────────┬────────────┐
│ name    ┆ reason                          ┆ usability ┆ processable ┆ … ┆ period ┆ run ┆ datatype ┆ psd_status │
│ ---     ┆ ---                             ┆ ---       ┆ ---         ┆   ┆ ---    ┆ --- ┆ ---      ┆ ---        │
│ str     ┆ str                             ┆ str       ┆ bool        ┆   ┆ i32    ┆ i32 ┆ str      ┆ struct[3]  │
╞═════════╪═════════════════════════════════╪═══════════╪═════════════╪═══╪════════╪═════╪══════════╪════════════╡
│ P00662A ┆ ringing ortec                   ┆ on        ┆ true        ┆ … ┆ 3      ┆ 0   ┆ cal      ┆ null       │
│ B00079B ┆                                 ┆ on        ┆ true        ┆ … ┆ 3      ┆ 0   ┆ cal      ┆ null       │
│ P00538A ┆                                 ┆ on        ┆ true        ┆ … ┆ 3      ┆ 0   ┆ cal      ┆ null       │
│ S048    ┆ null                            ┆ on        ┆ true        ┆ … ┆ 3      ┆ 0   ┆ cal      ┆ null       │
│ V05266B ┆                                 ┆ on        ┆ true        ┆ … ┆ 3      ┆ 0   ┆ cal      ┆ null       │
│ …       ┆ …                               ┆ …         ┆ …           ┆ … ┆ …      ┆ …   ┆ …        ┆ …          │
│ PMT504  ┆ null                            ┆ on        ┆ true        ┆ … ┆ 21     ┆ 2   ┆ pzc      ┆ null       │
│ V05261A ┆ [escale] r002-phy is bracketed… ┆ on        ┆ true        ┆ … ┆ 21     ┆ 2   ┆ pzc      ┆ null       │
│ V04545A ┆                                 ┆ on        ┆ true        ┆ … ┆ 21     ┆ 2   ┆ pzc      ┆ null       │
│ S093    ┆ null                            ┆ on        ┆ true        ┆ … ┆ 21     ┆ 2   ┆ pzc      ┆ null       │
│ PMT507  ┆ null                            ┆ on        ┆ true        ┆ … ┆ 21     ┆ 2   ┆ pzc      ┆ null       │
└─────────┴─────────────────────────────────┴───────────┴─────────────┴───┴────────┴─────┴──────────┴────────────┘

In [4]: # channelmaps: per-subsystem, keyed on period
   ...: lmeta.tables.channelmaps.geds.filter(pl.col("period") == 10)
Out[4]:
shape: (101, 8)
┌─────────┬────────┬───────────┬─────────────────────────────────┬─────────────────────────────────┬─────────────────────────────────┬────────┬─────────┐
│ name    ┆ system ┆ location  ┆ daq                             ┆ voltage                         ┆ electronics                     ┆ period ┆ rawid   │
│ ---     ┆ ---    ┆ ---       ┆ ---                             ┆ ---                             ┆ ---                             ┆ ---    ┆ ---     │
│ str     ┆ str    ┆ struct[2] ┆ struct[5]                       ┆ struct[4]                       ┆ struct[2]                       ┆ i64    ┆ i64     │
╞═════════╪════════╪═══════════╪═════════════════════════════════╪═════════════════════════════════╪═════════════════════════════════╪════════╪═════════╡
│ P00662A ┆ geds   ┆ {11,9}    ┆ {1,{8,"0x370",null},0,null,108… ┆ {{12,null},6,{"3",null},{"A","… ┆ {{"B2",null,2,null},{null,1,6,… ┆ 10     ┆ 1089600 │
│ B00079B ┆ geds   ┆ {4,6}     ┆ {0,{7,"0x470",null},4,null,111… ┆ {{0,null},5,{"1",null},{"D","1… ┆ {{"C5",null,5,null},{null,0,0,… ┆ 10     ┆ 1113604 │
│ P00538A ┆ geds   ┆ {9,6}     ┆ {1,{2,"0x320",null},4,null,108… ┆ {{8,null},5,{"10",null},{"A","… ┆ {{"C1",null,5,null},{null,0,2,… ┆ 10     ┆ 1080004 │
│ P00712A ┆ geds   ┆ {3,6}     ┆ {0,{6,"0x460",null},1,null,111… ┆ {{2,null},1,{"12",null},{"D","… ┆ {{"B5",null,3,null},{null,1,4,… ┆ 10     ┆ 1112001 │
│ V05266B ┆ geds   ┆ {1,5}     ┆ {0,{1,"0x410",null},4,null,110… ┆ {{6,null},4,{"9",null},{"B","3… ┆ {{"C3",null,4,null},{null,0,1,… ┆ 10     ┆ 1104004 │
│ …       ┆ …      ┆ …         ┆ …                               ┆ …                               ┆ …                               ┆ …      ┆ …       │
│ V05261A ┆ geds   ┆ {8,8}     ┆ {0,{12,"0x4c0",null},4,null,11… ┆ {{12,null},2,{"3",null},{"A","… ┆ {{"F2",null,0,null},{null,2,4,… ┆ 10     ┆ 1121604 │
│ P00574B ┆ geds   ┆ {3,3}     ┆ {0,{5,"0x450",null},4,null,111… ┆ {{1,null},6,{"14",null},{"D","… ┆ {{"B5",null,0,null},{null,1,4,… ┆ 10     ┆ 1110404 │
│ C00ANG2 ┆ geds   ┆ {2,6}     ┆ {0,{4,"0x440",null},1,null,110… ┆ {{3,null},2,{"8",null},{"D","4… ┆ {{"A4",null,5,null},{null,1,1,… ┆ 10     ┆ 1108801 │
│ V04545A ┆ geds   ┆ {7,4}     ┆ {0,{10,"0x4a0",null},5,null,11… ┆ {{4,null},1,{"11",null},{"C","… ┆ {{"D2",null,3,null},{null,0,6,… ┆ 10     ┆ 1118405 │
│ V01240A ┆ geds   ┆ {10,10}   ┆ {1,{5,"0x350",null},4,null,108… ┆ {{10,null},6,{"5",null},{"A","… ┆ {{"B1",null,2,null},{null,1,2,… ┆ 10     ┆ 1084804 │
└─────────┴────────┴───────────┴─────────────────────────────────┴─────────────────────────────────┴─────────────────────────────────┴────────┴─────────┘

In [5]: # join detector hardware with channel map
   ...: lmeta.tables.channelmaps.geds.join(lmeta.tables.diodes, on="name")
/global/cfs/cdirs/m2676/users/yuanru/pygama-dev/pylegendmeta/src/legendmeta/tables.py:141: UserWarning: _textdb_to_df: skipping 1 sub-directories: ['simulation']
  return _textdb_to_df(self._lmeta.hardware.detectors.germanium.diodes)
Out[5]:
shape: (1_363, 12)
┌─────────┬────────┬───────────┬─────────────────────────────┬───┬──────┬────────────────────────────┬────────────────────────────┬────────────────────────────┐
│ name    ┆ system ┆ location  ┆ daq                         ┆ … ┆ type ┆ production                 ┆ geometry                   ┆ characterization           │
│ ---     ┆ ---    ┆ ---       ┆ ---                         ┆   ┆ ---  ┆ ---                        ┆ ---                        ┆ ---                        │
│ str     ┆ str    ┆ struct[2] ┆ struct[5]                   ┆   ┆ str  ┆ struct[10]                 ┆ struct[7]                  ┆ struct[3]                  │
╞═════════╪════════╪═══════════╪═════════════════════════════╪═══╪══════╪════════════════════════════╪════════════════════════════╪════════════════════════════╡
│ B00079B ┆ geds   ┆ {8,4}     ┆ {0,{9,"0x490",null},1,null, ┆ … ┆ bege ┆ {"Mirion",0,"079","B",{0.8 ┆ {29.04,38.42,null,{2.0,{10 ┆ {{3000.0,3500.0,0.648,1.82 │
│         ┆        ┆           ┆ 111…                        ┆   ┆      ┆ 74,0…                      ┆ .5,7…                      ┆ ,0.8…                      │
│ V14673A ┆ geds   ┆ {1,2}     ┆ {0,{1,"0x410",null},5,null, ┆ … ┆ icpc ┆ {"Mirion",14,"673","A",{nu ┆ {98.8,45.7,{6.0,65.5},{2.0 ┆ {{4200.0,5000.0,0.83,1.71, │
│         ┆        ┆           ┆ 110…                        ┆   ┆      ┆ ll,n…                      ┆ ,{15…                      ┆ 0.94…                      │
│ V05266B ┆ geds   ┆ {6,8}     ┆ {0,{7,"0x470",null},0,null, ┆ … ┆ icpc ┆ {"Mirion",5,"266","B",{0.9 ┆ {72.0,40.05,{4.0,41.9},{2. ┆ {{4500.0,5000.0,0.781,1.73 │
│         ┆        ┆           ┆ 111…                        ┆   ┆      ┆ 19,0…                      ┆ 0,{1…                      ┆ ,1.0…                      │
│ V07302B ┆ geds   ┆ {6,7}     ┆ {0,{6,"0x460",null},4,null, ┆ … ┆ icpc ┆ {"Mirion",7,"302","B",{0.9 ┆ {57.4,40.05,{4.0,30.0},{2. ┆ {{4500.0,5000.0,0.803,1.72 │
│         ┆        ┆           ┆ 111…                        ┆   ┆      ┆ 27,0…                      ┆ 0,{1…                      ┆ ,0.8…                      │
│ B00035A ┆ geds   ┆ {10,3}    ┆ {0,{10,"0x4a0",null},5,null ┆ … ┆ bege ┆ {"Mirion",0,"035","A",{0.8 ┆ {35.34,36.77,null,{2.0,{10 ┆ {{3000.0,4000.0,0.607,1.78 │
│         ┆        ┆           ┆ ,11…                        ┆   ┆      ┆ 74,0…                      ┆ .5,7…                      ┆ 5,0.…                      │
│ …       ┆ …      ┆ …         ┆ …                           ┆ … ┆ …    ┆ …                          ┆ …                          ┆ …                          │
│ V00048B ┆ geds   ┆ {4,6}     ┆ {0,{4,"0x440",null},0,null, ┆ … ┆ icpc ┆ {"Mirion",0,"048","B",{0.8 ┆ {80.5,36.3,{5.25,56.0},{2. ┆ {{3500.0,4000.0,0.779,1.82 │
│         ┆        ┆           ┆ 110…                        ┆   ┆      ┆ 78,0…                      ┆ 0,{1…                      ┆ ,nul…                      │
│ V00074A ┆ geds   ┆ {10,9}    ┆ {0,{12,"0x4c0",null},0,null ┆ … ┆ icpc ┆ {"Mirion",0,"074","A",{0.8 ┆ {82.3,38.3,{5.25,52.4},{2. ┆ {{4000.0,4500.0,0.897,1.76 │
│         ┆        ┆           ┆ ,11…                        ┆   ┆      ┆ 78,0…                      ┆ 0,{1…                      ┆ ,nul…                      │
│ V05261A ┆ geds   ┆ {4,9}     ┆ {0,{2,"0x420",null},2,null, ┆ … ┆ icpc ┆ {"Mirion",5,"261","A",{0.9 ┆ {65.2,40.05,{4.0,30.0},{2. ┆ {{3500.0,4000.0,0.799,2.18 │
│         ┆        ┆           ┆ 110…                        ┆   ┆      ┆ 18,0…                      ┆ 0,{1…                      ┆ ,0.9…                      │
│ V04545A ┆ geds   ┆ {12,3}    ┆ {1,{2,"0x320",null},2,null, ┆ … ┆ icpc ┆ {"Mirion",4,"545","A",{0.9 ┆ {100.5,42.5,{4.0,69.2},{2. ┆ {{4500.0,5000.0,0.765,2.56 │
│         ┆        ┆           ┆ 108…                        ┆   ┆      ┆ 13,0…                      ┆ 0,{1…                      ┆ ,0.8…                      │
│ V06643A ┆ geds   ┆ {10,8}    ┆ {0,{11,"0x4b0",null},5,null ┆ … ┆ icpc ┆ {"Ortec",6,"643","A",{null ┆ {90.5,39.1,{4.0,60.8},{2.0 ┆ {{null,3500.0,0.605,1.8,0. │
│         ┆        ┆           ┆ ,11…                        ┆   ┆      ┆ ,0.0…                      ┆ ,{18…                      ┆ 6,0.…                      │
└─────────┴────────┴───────────┴─────────────────────────────┴───┴──────┴────────────────────────────┴────────────────────────────┴────────────────────────────┘

```

## Design Decisions and Why

- `Tables` is built via a `cached_property` on `LegendMetadata`, so users who don't need tabular views pay no cost.
- Runinfo and statuses live at different paths depending on the metadata version (`datasets.*` vs `dataprod.*`). The resolvers try the current layout first and fall back to the legacy one.
- Our channel maps are constant within a period, so `channelmaps` tables are keyed on `period` rather than `(period, run)`.
- Each subsystem (`geds`, `spms`, ...) gets its own DataFrame because their schemas differ. They are grouped in an `AttrsDict` accessible by attribute or key (`tables.channelmaps.geds` or `tables.channelmaps["geds"]`).
- `_textdb_to_df`, which is used for static detector files, flattens a `TextDB` directory into a DataFrame. Nested `TextDB` entries (new sub-collections added to the metadata) are skipped with a warning, since merging them with the top-level table requires knowing their schemas; this module should be updated to materialize them as separate tables when that happens.

## Dependencies

Adds `polars>=1.40` as a direct dependency. Imported lazily inside `LegendMetadata.tables` so users not touching the tabular views see no extra import-time cost. Output is `pl.DataFrame`, convertible to PyArrow via `df.to_arrow()` (zero-copy) or pandas via `df.to_pandas()`.

## Testing

Verified against two `LegendMetadata` instances spanning the metadata schema migration (`inputs` in the reference production v2.1.5, and `v1.4.3`, the latest stable version). Coverage includes p13 (SiPM-only commissioning, no geds), `acs` runs with int-keyed `sis_setups` handled via `_stringify_keys`.

One known data quirk: in p15 r000, both `old_tst` and `tst` datatypes share the same `start_key`. This results in duplicated rows in `statuses` (distinguished by `datatype`) but does not affect `runinfo` (the primary key is `(period, run, datatype)`) or `channelmaps` (which deduplicates per period). Noting this for the record.
