### PR TITLE
feat: improve validate-validity hook with transitive reference detection and --exclude arg

### DIFF
--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -270,19 +270,20 @@ def len_nested(d: dict) -> int:
 
 def _find_unreferenced_files(
     validity_file: str,
-    referenced: set[str],
     exclude: list[str] | None = None,
     verbose: bool = True,
 ) -> list[str]:
-    """Find YAML/JSON data files not referenced in the validity file.
+    """Find YAML/JSON data files not transitively referenced via the validity file.
+
+    Loads the full resolved database state for every (timestamp, category) pair
+    and collects all file paths that appear as string values with the database
+    directory as prefix (i.e. all ``$_``-expanded references). Files listed
+    directly in ``apply`` entries are also considered referenced.
 
     Parameters
     ----------
     validity_file
         Path to the validity YAML file.
-    referenced
-        Set of file paths (relative to the validity file's directory) that
-        are referenced in the validity file's ``apply`` entries.
     exclude
         List of glob patterns (relative to the validity file's directory)
         to exclude from the unreferenced-file check. Dotfiles and files
@@ -295,10 +296,42 @@ def _find_unreferenced_files(
     list[str]
         Relative paths of unreferenced data files.
     """
-    parent = Path(validity_file).parent
+    parent = Path(validity_file).parent.resolve()
     exclude = exclude or []
-    unreferenced = []
+    db_dir_str = str(parent) + "/"
 
+    referenced: set[str] = set()
+
+    try:
+        valid_dic = Props.read_from(str(validity_file))
+    except Exception:
+        valid_dic = []
+
+    # Collect files listed directly in apply entries (top-level config files)
+    seen: set[tuple[str, str]] = set()
+    for dic in valid_dic:
+        for f in dic.get("apply", []):
+            if isinstance(f, str):
+                referenced.add(f)
+        ts = str(dic.get("valid_from", ""))
+        categories = dic.get("category", "all") or "all"
+        if isinstance(categories, str):
+            categories = [categories]
+        for cat in categories:
+            seen.add((ts, str(cat)))
+
+    # Collect transitive references by loading the full resolved state
+    db = TextDB(parent)
+    for ts, cat in seen:
+        try:
+            state = db.on(ts, system=cat)
+            for value in _iter_string_values(state):
+                if value.startswith(db_dir_str):
+                    referenced.add(value[len(db_dir_str) :])
+        except Exception:
+            pass
+
+    unreferenced = []
     for data_file in sorted(parent.rglob("*")):
         if not data_file.is_file():
             continue
@@ -382,7 +415,7 @@ def validate_validity():
                     valid = False
 
         # check for files not referenced in validity
-        if _find_unreferenced_files(file, referenced_files, exclude=args.exclude):
+        if _find_unreferenced_files(file, exclude=args.exclude):
             valid = False
 
     if not valid:

--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import re
 import sys
 from importlib import resources
@@ -268,7 +269,10 @@ def len_nested(d: dict) -> int:
 
 
 def _find_unreferenced_files(
-    validity_file: str, referenced: set[str], verbose: bool = True
+    validity_file: str,
+    referenced: set[str],
+    exclude: list[str] | None = None,
+    verbose: bool = True,
 ) -> list[str]:
     """Find YAML/JSON data files not referenced in the validity file.
 
@@ -279,6 +283,10 @@ def _find_unreferenced_files(
     referenced
         Set of file paths (relative to the validity file's directory) that
         are referenced in the validity file's ``apply`` entries.
+    exclude
+        List of glob patterns (relative to the validity file's directory)
+        to exclude from the unreferenced-file check. Dotfiles and files
+        inside hidden directories are always excluded.
     verbose
         If True, print error messages.
 
@@ -288,6 +296,7 @@ def _find_unreferenced_files(
         Relative paths of unreferenced data files.
     """
     parent = Path(validity_file).parent
+    exclude = exclude or []
     unreferenced = []
 
     for data_file in sorted(parent.rglob("*")):
@@ -300,6 +309,19 @@ def _find_unreferenced_files(
 
         rel = data_file.relative_to(parent)
 
+        # skip dotfiles and files inside hidden directories
+        if any(part.startswith(".") for part in rel.parts):
+            continue
+
+        rel_str = str(rel)
+
+        if any(
+            fnmatch.fnmatch(rel_str, pat)
+            or any(fnmatch.fnmatch(str(p), pat) for p in rel.parents if p != Path())
+            for pat in exclude
+        ):
+            continue
+
         # skip files in subdirectories that have their own validity.yaml
         skip = False
         for p in rel.parents:
@@ -309,7 +331,6 @@ def _find_unreferenced_files(
         if skip:
             continue
 
-        rel_str = str(rel)
         if rel_str not in referenced:
             unreferenced.append(rel_str)
             if verbose:
@@ -333,6 +354,14 @@ def validate_validity():
         prog="validate-validity", description="Validate LEGEND validity files"
     )
     parser.add_argument("files", nargs="+", help="validity files")
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="PATTERN",
+        help="glob pattern (relative to the validity file directory) to exclude"
+        " from the unreferenced-file check; may be repeated",
+    )
     args = parser.parse_args()
 
     valid = True
@@ -353,7 +382,7 @@ def validate_validity():
                     valid = False
 
         # check for files not referenced in validity
-        if _find_unreferenced_files(file, referenced_files):
+        if _find_unreferenced_files(file, referenced_files, exclude=args.exclude):
             valid = False
 
     if not valid:

--- a/tests/test_police.py
+++ b/tests/test_police.py
@@ -704,9 +704,8 @@ def test_find_unreferenced_files_all_referenced(tmp_path):
         tmp_path,
         [{"valid_from": "20230101T000000Z", "apply": ["a.yaml", "b.json"]}],
     )
-    referenced = {"a.yaml", "b.json"}
     result = police._find_unreferenced_files(
-        str(tmp_path / "validity.yaml"), referenced, verbose=False
+        str(tmp_path / "validity.yaml"), verbose=False
     )
     assert result == []
 
@@ -719,9 +718,8 @@ def test_find_unreferenced_files_detects_orphan(tmp_path):
         tmp_path,
         [{"valid_from": "20230101T000000Z", "apply": ["a.yaml"]}],
     )
-    referenced = {"a.yaml"}
     result = police._find_unreferenced_files(
-        str(tmp_path / "validity.yaml"), referenced, verbose=False
+        str(tmp_path / "validity.yaml"), verbose=False
     )
     assert "orphan.yaml" in result
 
@@ -734,9 +732,8 @@ def test_find_unreferenced_files_detects_orphan_json(tmp_path):
         tmp_path,
         [{"valid_from": "20230101T000000Z", "apply": ["a.yaml"]}],
     )
-    referenced = {"a.yaml"}
     result = police._find_unreferenced_files(
-        str(tmp_path / "validity.yaml"), referenced, verbose=False
+        str(tmp_path / "validity.yaml"), verbose=False
     )
     assert "orphan.json" in result
 
@@ -747,9 +744,8 @@ def test_find_unreferenced_files_ignores_validity_yaml(tmp_path):
         tmp_path,
         [{"valid_from": "20230101T000000Z", "apply": []}],
     )
-    referenced = set()
     result = police._find_unreferenced_files(
-        str(tmp_path / "validity.yaml"), referenced, verbose=False
+        str(tmp_path / "validity.yaml"), verbose=False
     )
     assert "validity.yaml" not in result
     assert result == []
@@ -763,9 +759,8 @@ def test_find_unreferenced_files_ignores_non_yaml_json(tmp_path):
         tmp_path,
         [{"valid_from": "20230101T000000Z", "apply": []}],
     )
-    referenced = set()
     result = police._find_unreferenced_files(
-        str(tmp_path / "validity.yaml"), referenced, verbose=False
+        str(tmp_path / "validity.yaml"), verbose=False
     )
     assert result == []
 
@@ -781,9 +776,8 @@ def test_find_unreferenced_files_skips_subdir_with_own_validity(tmp_path):
         tmp_path,
         [{"valid_from": "20230101T000000Z", "apply": []}],
     )
-    referenced = set()
     result = police._find_unreferenced_files(
-        str(tmp_path / "validity.yaml"), referenced, verbose=False
+        str(tmp_path / "validity.yaml"), verbose=False
     )
     assert result == []
 
@@ -798,9 +792,8 @@ def test_find_unreferenced_files_includes_subdir_without_validity(tmp_path):
         tmp_path,
         [{"valid_from": "20230101T000000Z", "apply": []}],
     )
-    referenced = set()
     result = police._find_unreferenced_files(
-        str(tmp_path / "validity.yaml"), referenced, verbose=False
+        str(tmp_path / "validity.yaml"), verbose=False
     )
     assert any("orphan.yaml" in r for r in result)
 
@@ -815,9 +808,8 @@ def test_find_unreferenced_files_subdir_file_referenced(tmp_path):
         tmp_path,
         [{"valid_from": "20230101T000000Z", "apply": ["sub/data.yaml"]}],
     )
-    referenced = {"sub/data.yaml"}
     result = police._find_unreferenced_files(
-        str(tmp_path / "validity.yaml"), referenced, verbose=False
+        str(tmp_path / "validity.yaml"), verbose=False
     )
     assert result == []
 


### PR DESCRIPTION
## Summary

- **Remove `--fix` from hook entries**: hooks now only report errors, never auto-modify files in pre-commit context
- **Preserve multiline block scalars** when rewriting YAML files via `_LiteralBlockDumper`
- **Fix 6 code-review findings** in `police.py` (DSP error message ordering, `startswith` trailing slash, validity filename check, category null guard, `frozenset`→`tuple` dedup keys, missing group check for direct evt configs)
- **Skip dotfiles** in `_find_unreferenced_files` (always) and add `--exclude PATTERN` CLI argument for additional glob exclusions
- **Smarter unreferenced-file detection**: instead of only checking direct `apply` entries, load the full resolved database state via `TextDB.on(ts, system=cat)` for every (timestamp, category) pair and collect all `$_`-expanded path strings as transitively referenced files; also resolve the parent path to absolute to avoid `startswith` mismatches when pre-commit passes relative paths from the git root

## Test plan

- [ ] All 137 existing tests pass (`pytest tests/test_police.py`)
- [ ] `pre-commit try-repo . validate-validity --all-files` in `dataprod/config` reports only genuinely unreferenced files (6), not the ~100 false positives from transitive references
- [ ] `pre-commit try-repo . validate-dataflow-config --all-files` reports real config errors only