### PR TITLE
feat: add head_ldo_snap table and LDO rail readings to status()

### DIFF
--- a/src/legendmeta/scdb_tables.py
+++ b/src/legendmeta/scdb_tables.py
@@ -239,3 +239,21 @@ class MuonInfo(Base):
 
     def asdict(self) -> AttrsDict:
         return AttrsDict({"group": self.group, "label": self.label})
+
+
+@dataclass
+class HeadLdoSnap(Base):
+    """Monitored parameters of the HEAD electronics LDO voltage regulators."""
+
+    __tablename__ = "head_ldo_snap"
+
+    rasp: Mapped[int]
+    addr: Mapped[int]
+    name: Mapped[str]
+    vmon: Mapped[float]
+    imon: Mapped[float]
+    almask: Mapped[int]
+    tstamp: Mapped[datetime] = db.orm.mapped_column(primary_key=True)
+
+    def asdict(self) -> AttrsDict:
+        return AttrsDict({"vmon": self.vmon, "imon": self.imon})

--- a/src/legendmeta/slowcontrol.py
+++ b/src/legendmeta/slowcontrol.py
@@ -28,6 +28,7 @@ from .scdb_tables import (
     DiodeConfMon,
     DiodeInfo,
     DiodeSnap,
+    HeadLdoSnap,
     MuonConfMon,
     MuonInfo,
     MuonSnap,
@@ -245,7 +246,9 @@ class LegendSlowControlDB:
 
         Collect all the relevant information about the status of a channel at a
         certain time from the Slow Control database, based on the channel type
-        (i.e. germanium detector, SiPM or PMT).
+        (i.e. germanium detector, SiPM or PMT). For channels served by a
+        front-end buffer card (HPGe and auxiliary channels), the LDO regulator
+        voltages are added to the output under a ``cc4`` sub-dictionary.
 
         Parameters
         ----------
@@ -270,6 +273,10 @@ class LegendSlowControlDB:
          'status': 1,
          'vset': 3400.0,
          'iset': 6.0,
+         ...
+         'cc4': {'vb': -0.029, 'vb1': 1.995, 'vb2': 2.005,
+                 'vcc': 8.956, 'vcc1': ..., 'vee': -2.99,
+                 'vee1': -9.054, 'vfet': 12.0},
          ...
 
         Warning
@@ -297,6 +304,11 @@ class LegendSlowControlDB:
         # prepare environment to perform query
         if not self.session:
             self.session = self.make_session()
+
+        # a front-end buffer card (HPGe and auxiliary channels) exposes LDO
+        # regulator voltages, queried independently of the system below
+        electronics = channel.get("electronics", {})
+        has_buffer_card = "buffer_card" in electronics
 
         output = AttrsDict()
         if system == "geds":
@@ -359,12 +371,40 @@ class LegendSlowControlDB:
                     continue
 
                 output |= result[0].asdict()
-        else:
+        elif not has_buffer_card:
             msg = f"System '{system}' not (yet) supported"
             raise NotImplementedError(msg)
 
+        # LDO regulator voltages, for any channel with a front-end buffer card
+        if has_buffer_card:
+            rasp = electronics.buffer_card.raspberry_pi
+            address = electronics.buffer_card.address
+            cc4 = AttrsDict()
+            for rail in ("VB", "VB1", "VB2", "VCC", "VCC1", "VEE", "VEE1", "VFET"):
+                stmt = (
+                    db.select(HeadLdoSnap)
+                    .where(HeadLdoSnap.rasp == rasp)
+                    .where(HeadLdoSnap.addr == address)
+                    .where(HeadLdoSnap.name == rail)
+                    .order_by(HeadLdoSnap.tstamp.desc())
+                    .where(HeadLdoSnap.tstamp <= on)
+                    .limit(1)
+                )
+
+                result = self.session.execute(stmt).first()
+
+                if not result:
+                    msg = f"Query on table 'head_ldo_snap' for rail '{rail}' did not produce any result"
+                    log.warning(msg)
+                    continue
+
+                cc4[rail.lower()] = result[0].vmon
+
+            if cc4:
+                output["cc4"] = cc4
+
         if not output:
             msg = "Could not obtain any information about the channel"
-            raise RuntimeError()
+            raise RuntimeError(msg)
 
         return output

--- a/tests/test_slowcontroldb.py
+++ b/tests/test_slowcontroldb.py
@@ -7,6 +7,7 @@ import sqlalchemy as sql
 from dbetto import AttrsDict
 
 from legendmeta import LegendMetadata, LegendSlowControlDB
+from legendmeta.scdb_tables import HeadLdoSnap
 from legendmeta.slowcontrol import DiodeSnap
 
 pytestmark = [
@@ -36,6 +37,14 @@ def test_select(scdb):
     session.close()
 
 
+def test_select_head_ldo(scdb):
+    session = scdb.make_session()
+    query = sql.select(HeadLdoSnap).limit(10)
+    result = session.execute(query).all()
+    assert len(result) == 10
+    session.close()
+
+
 def test_str_table_pandas(scdb):
     data = scdb.dataframe("diode_snap_last")
     assert len(data) > 0
@@ -59,12 +68,30 @@ def test_status(scdb):
     assert isinstance(status, AttrsDict)
     assert "vmon" in status
     assert "vset" in status
+    assert "cc4" in status
+    for rail in ("vb", "vb1", "vb2", "vcc", "vcc1", "vee", "vee1", "vfet"):
+        assert rail in status.cc4
+        assert isinstance(status.cc4[rail], float)
 
     channel = chmap.S002
     status = scdb.status(channel)
     assert isinstance(status, AttrsDict)
     assert "vmon" in status
     assert "vset" in status
+
+    # LDO rails are also available for aux channels with a buffer card
+    channel = next(
+        v
+        for v in chmap.values()
+        if getattr(v, "system", None) == "auxs"
+        and "buffer_card" in v.get("electronics", {})
+    )
+    status = scdb.status(channel)
+    assert isinstance(status, AttrsDict)
+    assert "cc4" in status
+    for rail in ("vb", "vb1", "vb2", "vcc", "vcc1", "vee", "vee1", "vfet"):
+        assert rail in status.cc4
+        assert isinstance(status.cc4[rail], float)
 
 
 def test_pickle_legend_slowcontrol_db_roundtrip(scdb):


### PR DESCRIPTION
## Summary

- Add the `HeadLdoSnap` ORM mapping for the `head_ldo_snap` slow control table. The schema (`rasp`, `addr`, `name`, `vmon`, `imon`, `almask`, `tstamp`) was read directly from the live Slow Control database.
- Wire all LDO regulator voltages into `LegendSlowControlDB.status()`: for any channel served by a front-end buffer card (HPGe `geds` and auxiliary `auxs` channels), all 8 rails present in the database (`VB`, `VB1`, `VB2`, `VCC`, `VCC1`, `VEE`, `VEE1`, `VFET`) are added to the returned dict under a `cc4` sub-dictionary as scalar `vmon` values. The query triggers on the presence of `electronics.buffer_card` in the channel map, so SiPM/PMT channels (no buffer card) are unaffected, and the `auxs` system is no longer rejected by `status()`.
- Fix `status()` raising `RuntimeError` without its message.

## Details

The buffer-card identifiers come from the channel map:

\`\`\`python
rasp    = channel.electronics.buffer_card.raspberry_pi
address = channel.electronics.buffer_card.address
\`\`\`

Example output for a geds channel:

\`\`\`python
{
  'vmon': 3399.9, 'imon': 0.00015, 'status': 1, 'vset': 3400.0, ...,
  'cc4': {
    'vb': -0.029, 'vb1': 1.995, 'vb2': 2.005,
    'vcc': 8.956,  'vcc1': 3.004,
    'vee': -2.99,  'vee1': -9.054,
    'vfet': 12.0,
  }
}
\`\`\`

## Testing

- Added `test_select_head_ldo` and extended `test_status` to cover the geds and aux channel `cc4` sub-dict (both marked `needs_slowcontrol`/`xfail`, so they require database access to run).
- Verified against the live database for both geds (`V02162B`) and auxs channels.
- `pre-commit` passes on all changed files.

## AI assistance disclosure

Per the project AI policy, this contribution was drafted with AI assistance (Claude Code) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)