### PR TITLE
Add runlists and ignored_daq_cycles tabular views

### DIFF
--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -47,6 +47,36 @@ def _textdb_to_df(db) -> pl.DataFrame:
     return pl.from_dicts(file_items, strict=False, infer_schema_length=None)
 
 
+def _expand_run_spec(spec: str) -> list[int]:
+    """Expand a ``runlists.yaml`` entry into integer run numbers.
+
+    Each entry is either a single run (``"r000"``) or an inclusive range
+    (``"r000..r005"``, expanding to ``[0, 1, 2, 3, 4, 5]``).
+    """
+    if ".." in spec:
+        lo, hi = spec.split("..")
+        return list(range(int(lo.removeprefix("r")), int(hi.removeprefix("r")) + 1))
+    return [int(spec.removeprefix("r"))]
+
+
+def _parse_cycle_key(key: str) -> dict:
+    """Split a DAQ cycle key into its component fields.
+
+    Keys look like ``l200-p02-r008-cal-20230111T203016Z``; the original
+    string is preserved under ``key`` and ``period``/``run`` are returned as
+    integers so the row joins on the :attr:`LegendMetadataTables.runinfo` key columns.
+    """
+    experiment, period, run, datatype, timestamp = key.split("-")
+    return {
+        "key": key,
+        "experiment": experiment,
+        "period": int(period.removeprefix("p")),
+        "run": int(run.removeprefix("r")),
+        "datatype": datatype,
+        "timestamp": timestamp,
+    }
+
+
 def _stringify_keys(obj):
     """Recursively coerce dict keys to strings.
 
@@ -59,7 +89,7 @@ def _stringify_keys(obj):
     return obj
 
 
-class Tables:
+class LegendMetadataTables:
     """Polars DataFrame views over LEGEND metadata.
 
     Materializes and caches the dict-of-dict metadata structures into tabular
@@ -70,9 +100,9 @@ class Tables:
     Examples
     --------
     >>> from legendmeta import LegendMetadata
-    >>> from legendmeta.tables import Tables
+    >>> from legendmeta.tables import LegendMetadataTables
     >>> lmeta = LegendMetadata()
-    >>> tables = Tables(lmeta)
+    >>> tables = LegendMetadataTables(lmeta)
     >>> tables.runinfo
     """
 
@@ -93,6 +123,60 @@ class Tables:
                 for p, runs in _runinfo.items()
                 for r, datatypes in runs.items()
                 for dt, info in datatypes.items()
+            ],
+            strict=False,
+            infer_schema_length=None,
+        )
+
+    @cached_property
+    def runlists(self) -> pl.DataFrame:
+        """Named run selections (``valid``, ``0vbb``, ...) in long form.
+
+        ``runlists.yaml`` nests each named list as
+        ``{datatype: {period: [run specs]}}``, where a spec is a single run
+        (``"r000"``) or an inclusive range (``"r000..r005"``). This flattens
+        and expands those into one row per ``(runlist, period, run,
+        datatype)``, matching the :attr:`runinfo` key columns so the two
+        join directly (e.g. semi-join ``runinfo`` to keep only valid runs).
+        """
+        _runlists = self._lmeta.datasets.runlists
+        return pl.from_dicts(
+            [
+                {
+                    "runlist": listname,
+                    "period": int(p.removeprefix("p")),
+                    "run": run,
+                    "datatype": dt,
+                }
+                for listname, by_datatype in _runlists.items()
+                for dt, by_period in by_datatype.items()
+                for p, specs in by_period.items()
+                for spec in specs
+                for run in _expand_run_spec(spec)
+            ],
+            strict=False,
+            infer_schema_length=None,
+        )
+
+    @cached_property
+    def ignored_daq_cycles(self) -> pl.DataFrame:
+        """DAQ cycles excluded from processing, in long form.
+
+        ``ignored_daq_cycles.yaml`` lists cycle keys under a few categories
+        (``unprocessable``, ``removed``). Each key
+        (``l200-p02-r008-cal-20230111T203016Z``) is split into its
+        ``(experiment, period, run, datatype, timestamp)`` fields — with the
+        raw string kept as ``key`` and the category as ``category`` — so the
+        table joins on the :attr:`runinfo` key columns (e.g. anti-join to drop
+        ignored runs). Note the per-entry reasons live in YAML comments and so
+        are not recoverable here.
+        """
+        _ignored = self._lmeta.datasets.ignored_daq_cycles
+        return pl.from_dicts(
+            [
+                {"category": category, **_parse_cycle_key(key)}
+                for category, keys in _ignored.items()
+                for key in keys
             ],
             strict=False,
             infer_schema_length=None,

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import re
 import warnings
 from functools import cached_property
 
 import polars as pl
 from dbetto import AttrsDict, TextDB
+
+from .utils import expand_runs
 
 
 def _resolve_runinfo(lmeta):
@@ -47,18 +50,6 @@ def _textdb_to_df(db) -> pl.DataFrame:
     return pl.from_dicts(file_items, strict=False, infer_schema_length=None)
 
 
-def _expand_run_spec(spec: str) -> list[int]:
-    """Expand a ``runlists.yaml`` entry into integer run numbers.
-
-    Each entry is either a single run (``"r000"``) or an inclusive range
-    (``"r000..r005"``, expanding to ``[0, 1, 2, 3, 4, 5]``).
-    """
-    if ".." in spec:
-        lo, hi = spec.split("..")
-        return list(range(int(lo.removeprefix("r")), int(hi.removeprefix("r")) + 1))
-    return [int(spec.removeprefix("r"))]
-
-
 def _parse_cycle_key(key: str) -> dict:
     """Split a DAQ cycle key into its component fields.
 
@@ -66,7 +57,7 @@ def _parse_cycle_key(key: str) -> dict:
     string is preserved under ``key`` and ``period``/``run`` are returned as
     integers so the row joins on the :attr:`LegendMetadataTables.runinfo` key columns.
     """
-    experiment, period, run, datatype, timestamp = key.split("-")
+    experiment, period, run, datatype, timestamp = re.split(r"\W+", key)
     return {
         "key": key,
         "experiment": experiment,
@@ -145,14 +136,13 @@ class LegendMetadataTables:
                 {
                     "runlist": listname,
                     "period": int(p.removeprefix("p")),
-                    "run": run,
+                    "run": int(run.removeprefix("r")),
                     "datatype": dt,
                 }
                 for listname, by_datatype in _runlists.items()
                 for dt, by_period in by_datatype.items()
                 for p, specs in by_period.items()
-                for spec in specs
-                for run in _expand_run_spec(spec)
+                for run in expand_runs(specs)
             ],
             strict=False,
             infer_schema_length=None,

--- a/src/legendmeta/tables.py
+++ b/src/legendmeta/tables.py
@@ -165,10 +165,10 @@ class LegendMetadataTables:
         ``ignored_daq_cycles.yaml`` lists cycle keys under a few categories
         (``unprocessable``, ``removed``). Each key
         (``l200-p02-r008-cal-20230111T203016Z``) is split into its
-        ``(experiment, period, run, datatype, timestamp)`` fields — with the
-        raw string kept as ``key`` and the category as ``category`` — so the
-        table joins on the :attr:`runinfo` key columns (e.g. anti-join to drop
-        ignored runs). Note the per-entry reasons live in YAML comments and so
+        ``(experiment, period, run, datatype, timestamp)`` fields, with the
+        raw string kept as ``key`` and the category as ``category``. Rows are
+        at cycle granularity (one per ``timestamp``), finer than
+        :attr:`runinfo`. The per-entry reasons live in YAML comments and so
         are not recoverable here.
         """
         _ignored = self._lmeta.datasets.ignored_daq_cycles

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -88,7 +88,9 @@ def test_runlists(metadb):
     )
     runlist_keys = df.select("period", "run", "datatype").unique()
     matched = runlist_keys.join(runinfo_keys, on=["period", "run", "datatype"])
-    orphans = runlist_keys.join(runinfo_keys, on=["period", "run", "datatype"], how="anti")
+    orphans = runlist_keys.join(
+        runinfo_keys, on=["period", "run", "datatype"], how="anti"
+    )
     assert matched.height > orphans.height
 
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -58,7 +58,7 @@ def test_runlists(metadb):
     assert len(df) > 0
     assert {"runlist", "period", "run", "datatype"}.issubset(df.columns)
 
-    # ranges are expanded: p03 cal "valid" covers r000..r005 -> 6 rows
+    # single inclusive range expands fully: p03 cal "valid" -> r000..r005
     valid_p03_cal = df.filter(
         (pl.col("runlist") == "valid")
         & (pl.col("period") == 3)
@@ -66,18 +66,30 @@ def test_runlists(metadb):
     )
     assert set(valid_p03_cal["run"].to_list()) == {0, 1, 2, 3, 4, 5}
 
-    # runlist rows reference real runinfo rows
+    # multiple ranges concatenate and gaps are preserved: p08 phy "valid"
+    # is "r000..r004" + "r006..r014", so r005 is excluded
+    valid_p08_phy = df.filter(
+        (pl.col("runlist") == "valid")
+        & (pl.col("period") == 8)
+        & (pl.col("datatype") == "phy")
+    )
+    assert set(valid_p08_phy["run"].to_list()) == {0, 1, 2, 3, 4, *range(6, 15)}
+
+    # expansion/flattening never double-counts a run
+    assert df.is_duplicated().sum() == 0
+
+    # runlist keys mostly resolve to real runinfo rows; a few upstream
+    # entries legitimately have no runinfo row (e.g. a phy run listed where
+    # runinfo only records cal), but a key-parsing bug would flip this ratio
     runinfo_keys = (
         LegendMetadataTables(metadb)
         .runinfo.select("period", "run", "datatype")
         .unique()
     )
-    joined = (
-        df.select("period", "run", "datatype")
-        .unique()
-        .join(runinfo_keys, on=["period", "run", "datatype"], how="inner")
-    )
-    assert joined.height > 0
+    runlist_keys = df.select("period", "run", "datatype").unique()
+    matched = runlist_keys.join(runinfo_keys, on=["period", "run", "datatype"])
+    orphans = runlist_keys.join(runinfo_keys, on=["period", "run", "datatype"], how="anti")
+    assert matched.height > orphans.height
 
 
 def test_ignored_daq_cycles(metadb):

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -67,9 +67,15 @@ def test_runlists(metadb):
     assert set(valid_p03_cal["run"].to_list()) == {0, 1, 2, 3, 4, 5}
 
     # runlist rows reference real runinfo rows
-    runinfo_keys = LegendMetadataTables(metadb).runinfo.select("period", "run", "datatype").unique()
-    joined = df.select("period", "run", "datatype").unique().join(
-        runinfo_keys, on=["period", "run", "datatype"], how="inner"
+    runinfo_keys = (
+        LegendMetadataTables(metadb)
+        .runinfo.select("period", "run", "datatype")
+        .unique()
+    )
+    joined = (
+        df.select("period", "run", "datatype")
+        .unique()
+        .join(runinfo_keys, on=["period", "run", "datatype"], how="inner")
     )
     assert joined.height > 0
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -9,7 +9,7 @@ from dbetto import AttrsDict
 from git import GitCommandError
 
 from legendmeta import LegendMetadata
-from legendmeta.tables import Tables
+from legendmeta.tables import LegendMetadataTables
 
 pytestmark = [
     pytest.mark.xfail(run=True, reason="requires access to legend-metadata"),
@@ -45,15 +45,53 @@ def metadb_v056():
 
 def test_runinfo(metadb):
     metadb.scan()
-    df = Tables(metadb).runinfo
+    df = LegendMetadataTables(metadb).runinfo
     assert isinstance(df, pl.DataFrame)
     assert len(df) > 0
     assert {"period", "run", "datatype"}.issubset(df.columns)
 
 
+def test_runlists(metadb):
+    metadb.scan()
+    df = LegendMetadataTables(metadb).runlists
+    assert isinstance(df, pl.DataFrame)
+    assert len(df) > 0
+    assert {"runlist", "period", "run", "datatype"}.issubset(df.columns)
+
+    # ranges are expanded: p03 cal "valid" covers r000..r005 -> 6 rows
+    valid_p03_cal = df.filter(
+        (pl.col("runlist") == "valid")
+        & (pl.col("period") == 3)
+        & (pl.col("datatype") == "cal")
+    )
+    assert set(valid_p03_cal["run"].to_list()) == {0, 1, 2, 3, 4, 5}
+
+    # runlist rows reference real runinfo rows
+    runinfo_keys = LegendMetadataTables(metadb).runinfo.select("period", "run", "datatype").unique()
+    joined = df.select("period", "run", "datatype").unique().join(
+        runinfo_keys, on=["period", "run", "datatype"], how="inner"
+    )
+    assert joined.height > 0
+
+
+def test_ignored_daq_cycles(metadb):
+    metadb.scan()
+    df = LegendMetadataTables(metadb).ignored_daq_cycles
+    assert isinstance(df, pl.DataFrame)
+    assert len(df) > 0
+    assert {"category", "key", "period", "run", "datatype", "timestamp"}.issubset(
+        df.columns
+    )
+
+    # the compound key is split into typed columns
+    assert df["period"].dtype == pl.Int64
+    assert df["run"].dtype == pl.Int64
+    assert set(df["category"].unique()).issubset({"unprocessable", "removed"})
+
+
 def test_statuses(metadb):
     metadb.scan()
-    df = Tables(metadb).statuses
+    df = LegendMetadataTables(metadb).statuses
     assert isinstance(df, pl.DataFrame)
     assert len(df) > 0
     assert {"period", "run", "datatype", "name"}.issubset(df.columns)
@@ -61,7 +99,7 @@ def test_statuses(metadb):
 
 def test_channelmaps(metadb):
     metadb.scan()
-    tables = Tables(metadb)
+    tables = LegendMetadataTables(metadb)
     chmaps = tables.channelmaps
     assert isinstance(chmaps, AttrsDict)
     assert "geds" in chmaps
@@ -85,7 +123,7 @@ def test_channelmaps(metadb):
 
 def test_detector_tables(metadb):
     metadb.scan()
-    tables = Tables(metadb)
+    tables = LegendMetadataTables(metadb)
     for name in ("crystals", "sipms", "fibers"):
         df = getattr(tables, name)
         assert isinstance(df, pl.DataFrame)
@@ -98,13 +136,13 @@ def test_detector_tables(metadb):
 
 def test_tables_cached(metadb):
     metadb.scan()
-    tables = Tables(metadb)
+    tables = LegendMetadataTables(metadb)
     assert tables.runinfo is tables.runinfo
 
 
 def test_runinfo_v056(metadb_v056):
     metadb_v056.scan()
-    df = Tables(metadb_v056).runinfo
+    df = LegendMetadataTables(metadb_v056).runinfo
     assert isinstance(df, pl.DataFrame)
     assert len(df) > 0
     assert {"period", "run", "datatype"}.issubset(df.columns)
@@ -112,7 +150,7 @@ def test_runinfo_v056(metadb_v056):
 
 def test_statuses_v056(metadb_v056):
     metadb_v056.scan()
-    df = Tables(metadb_v056).statuses
+    df = LegendMetadataTables(metadb_v056).statuses
     assert isinstance(df, pl.DataFrame)
     assert len(df) > 0
     assert {"period", "run", "datatype", "name"}.issubset(df.columns)
@@ -120,7 +158,7 @@ def test_statuses_v056(metadb_v056):
 
 def test_channelmaps_v056(metadb_v056):
     metadb_v056.scan()
-    chmaps = Tables(metadb_v056).channelmaps
+    chmaps = LegendMetadataTables(metadb_v056).channelmaps
     assert isinstance(chmaps, AttrsDict)
     assert "geds" in chmaps
     assert isinstance(chmaps.geds, pl.DataFrame)


### PR DESCRIPTION
Extend LegendMetadataTables with two more join-friendly DataFrame views over datasets/ metadata, keyed on (period, run, datatype) like runinfo:

- runlists: flattens named run selections (valid, 0vbb, nu24, taup), expanding "r000..r005" range shorthand into one row per run
- ignored_daq_cycles: splits the compound cycle key (l200-p02-r008-cal-20230111T203016Z) into typed columns; per-entry reasons live in YAML comments and are not recoverable

Both files are datasets/-only (absent at v0.5.6), so no dataprod fallback.

Also rename the Tables class to LegendMetadataTables.
