### PR TITLE
feat: add FileKey class for parsing LEGEND file keys

### DIFF
--- a/src/legendmeta/__init__.py
+++ b/src/legendmeta/__init__.py
@@ -24,9 +24,11 @@ from .core import MetadataRepository
 from .hadesmetadata import HadesMetadata
 from .legendmetadata import LegendMetadata
 from .slowcontrol import LegendSlowControlDB
+from .utils import FileKey
 
 __all__ = [
     "AttrsDict",
+    "FileKey",
     "HadesMetadata",
     "JsonDB",
     "LegendMetadata",

--- a/src/legendmeta/utils.py
+++ b/src/legendmeta/utils.py
@@ -1,9 +1,49 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+
+from dbetto import str_to_datetime
 
 _RUN_RANGE_PATTERN = re.compile(r"^r\d{3}\.\.r\d{3}$")
 _RUN_PATTERN = re.compile(r"^r\d{3}$")
+
+_FILE_KEY_PATTERN = re.compile(r"^[^-]+-[^-]+-[^-]+-[^-]+-\d{8}T\d{6}Z$")
+
+
+@dataclass(frozen=True, init=False)
+class FileKey:
+    """A parsed LEGEND file key of the form ``experiment-period-run-category-timestamp``."""
+
+    experiment: str
+    period: str
+    run: str
+    category: str
+    timestamp: str
+
+    def __init__(self, key: str) -> None:
+        if not _FILE_KEY_PATTERN.match(key):
+            msg = f"invalid file key format: {key!r}"
+            raise ValueError(msg)
+        experiment, period, run, category, timestamp = key.split("-", 4)
+        try:
+            str_to_datetime(timestamp)
+        except ValueError as e:
+            msg = f"invalid file key format: {key!r}"
+            raise ValueError(msg) from e
+        object.__setattr__(self, "experiment", experiment)
+        object.__setattr__(self, "period", period)
+        object.__setattr__(self, "run", run)
+        object.__setattr__(self, "category", category)
+        object.__setattr__(self, "timestamp", timestamp)
+
+    def __str__(self) -> str:
+        return f"{self.experiment}-{self.period}-{self.run}-{self.category}-{self.timestamp}"
+
+    @property
+    def datetime(self):
+        """The timestamp as a :class:`datetime.datetime` object."""
+        return str_to_datetime(self.timestamp)
 
 
 def expand_runs(spec: object) -> list[str]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from legendmeta import FileKey
+from legendmeta.utils import expand_runs
+
+
+def test_filekey_parsing():
+    key = FileKey("l200-p10-r001-phy-20230101T000000Z")
+    assert key.experiment == "l200"
+    assert key.period == "p10"
+    assert key.run == "r001"
+    assert key.category == "phy"
+    assert key.timestamp == "20230101T000000Z"
+
+
+def test_filekey_datetime():
+    key = FileKey("l200-p03-r000-cal-20230501T205951Z")
+    assert key.datetime.replace(tzinfo=None) == datetime(2023, 5, 1, 20, 59, 51)
+
+
+def test_filekey_str_roundtrip():
+    raw = "l200-p10-r001-phy-20230101T000000Z"
+    assert str(FileKey(raw)) == raw
+
+
+def test_filekey_immutable():
+    key = FileKey("l200-p10-r001-phy-20230101T000000Z")
+    with pytest.raises((AttributeError, TypeError)):
+        key.experiment = "l60"  # type: ignore[misc]
+
+
+def test_filekey_equality_and_hash():
+    raw = "l200-p10-r001-phy-20230101T000000Z"
+    assert FileKey(raw) == FileKey(raw)
+    assert hash(FileKey(raw)) == hash(FileKey(raw))
+    assert FileKey(raw) != FileKey("l200-p10-r002-phy-20230101T000000Z")
+    assert len({FileKey(raw), FileKey(raw)}) == 1
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "bad-key",
+        "l200-p10-r001-phy",
+        "l200-p10-r001-phy-20230101T000000Z-extra",
+        "l200-p10-r001-phy-2023-01-01T000000Z",
+        "l200-p10-r001-phy-notatimestamp",
+        "l200-p10-r001-phy-20230230T000000Z",  # Feb 30 matches the regex but is not a real date
+        "",
+    ],
+)
+def test_filekey_invalid(bad):
+    with pytest.raises(ValueError, match="invalid file key format"):
+        FileKey(bad)
+
+
+def test_expand_runs_single():
+    assert expand_runs("r001") == ["r001"]
+
+
+def test_expand_runs_range():
+    assert expand_runs("r000..r003") == ["r000", "r001", "r002", "r003"]
+    assert expand_runs("r005..r005") == ["r005"]
+
+
+def test_expand_runs_list():
+    assert expand_runs(["r001", "r003"]) == ["r001", "r003"]
+    assert expand_runs(["r000..r002", "r005"]) == ["r000", "r001", "r002", "r005"]
+
+
+def test_expand_runs_invalid():
+    assert expand_runs("foo") == []
+    assert expand_runs("p03") == []
+    assert expand_runs("") == []
+    assert expand_runs(42) == []
+    assert expand_runs([]) == []


### PR DESCRIPTION
## Summary

Adds a lightweight, immutable `FileKey` class to `legendmeta.utils` (also exported from the top-level `legendmeta` namespace) for parsing LEGEND file keys of the form `experiment-period-run-category-timestamp`.

```python
>>> from legendmeta import FileKey
>>> k = FileKey("l200-p10-r001-phy-20230101T000000Z")
>>> k.experiment, k.period, k.run, k.category, k.timestamp
('l200', 'p10', 'r001', 'phy', '20230101T000000Z')
>>> k.datetime
datetime.datetime(2023, 1, 1, 0, 0, tzinfo=...)
>>> str(k)
'l200-p10-r001-phy-20230101T000000Z'
```

### Details

- Implemented as a frozen `dataclass` with a single-string constructor, giving free equality, hashing and immutability.
- Validates the key format on construction and raises `ValueError` on malformed input.
- The legend-style timestamp is parsed via the existing `dbetto.str_to_datetime` through a `.datetime` property.

## Tests

New `tests/test_utils.py` covering:
- `FileKey`: parsing, attribute access, `.datetime`, `str()` round-trip, immutability, equality/hashing, and parametrized invalid inputs.
- `expand_runs`: single run, ranges, lists, and invalid inputs (previously untested).