### PR TITLE
fix: adopt dbetto's renamed 'category' argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "packaging",
-    "dbetto>=1.3.5",
+    "dbetto>=1.4",
     "GitPython",
     "pandas",
     "pyyaml",

--- a/src/legendmeta/legendmetadata.py
+++ b/src/legendmeta/legendmetadata.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from copy import deepcopy
 from datetime import datetime
 
@@ -59,8 +60,10 @@ class LegendMetadata(MetadataRepository):
     def channelmap(
         self,
         on: str | datetime | None = None,
-        system: str = "all",
+        category: str = "all",
         skip_version_check: bool = False,
+        *,
+        system: str | None = None,
     ) -> AttrsDict:
         """Get a LEGEND channel map.
 
@@ -74,8 +77,12 @@ class LegendMetadata(MetadataRepository):
         on
             a :class:`~datetime.datetime` object or a string matching the
             pattern ``YYYYmmddTHHMMSSZ``.
-        system: 'all', 'phy', 'cal', 'lar', ...
-            query only a data taking "system".
+        category: 'all', 'phy', 'cal', 'lar', ...
+            query only a data taking category.
+        system
+            deprecated alias for `category`. Do not confuse with the detector
+            "system" (``geds``, ``spms``, ...): here the accepted values are
+            data-taking categories.
         skip_version_check
             if ``True``, skip the git version check and assume the latest
             metadata structure. This is useful when working with non-git
@@ -101,21 +108,33 @@ class LegendMetadata(MetadataRepository):
         --------
         .textdb.TextDB.on
         """
+        if system is not None:
+            warnings.warn(
+                "the 'system' argument is deprecated, use 'category' instead",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            category = system
+
         if on is None:
             on = datetime.now()
 
         chmap = deepcopy(
-            self.hardware.configuration.channelmaps.on(on, pattern=None, system=system)
+            self.hardware.configuration.channelmaps.on(
+                on, pattern=None, category=category
+            )
         )
 
         # get analysis metadata
         if skip_version_check:
             # assume latest structure (post v0.5.9)
-            anamap = self.datasets.statuses.on(on, pattern=None, system=system)
+            anamap = self.datasets.statuses.on(on, pattern=None, category=category)
         elif self.__closest_tag__ < Version("v0.5.9") or self.__version__ == "v0.5.9":
-            anamap = self.dataprod.config.on(on, pattern=None, system=system).analysis
+            anamap = self.dataprod.config.on(
+                on, pattern=None, category=category
+            ).analysis
         else:
-            anamap = self.datasets.statuses.on(on, pattern=None, system=system)
+            anamap = self.datasets.statuses.on(on, pattern=None, category=category)
 
         # get full detector db
         detdb = self.hardware.detectors

--- a/src/legendmeta/police.py
+++ b/src/legendmeta/police.py
@@ -111,8 +111,8 @@ def validate_legend_channel_map() -> bool:
             validity = yaml.safe_load(f)
             for line in validity():
                 ts = line["valid_from"]
-                sy = line["apply"]
-                chmap = db.on(ts, system=sy)
+                cat = line["apply"]
+                chmap = db.on(ts, category=cat)
 
                 for k, v in chmap.items():
                     if "system" not in v:
@@ -324,7 +324,7 @@ def _find_unreferenced_files(
     db = TextDB(parent)
     for ts, cat in seen:
         try:
-            state = db.on(ts, system=cat)
+            state = db.on(ts, category=cat)
             for value in _iter_string_values(state):
                 if value.startswith(db_dir_str):
                     referenced.add(value[len(db_dir_str) :])
@@ -1804,7 +1804,7 @@ def validate_dataflow_config() -> None:
 
         for ts, cat in sorted(seen):
             try:
-                state = db.on(ts, system=cat)
+                state = db.on(ts, category=cat)
             except Exception as e:
                 print(  # noqa: T201
                     f"ERROR: could not load dataflow config at '{ts}'"

--- a/tests/test_lmeta.py
+++ b/tests/test_lmeta.py
@@ -119,12 +119,17 @@ def test_channelmap(metadb):
     assert hasattr(channel, "geometry")
     assert "analysis" in channel
 
-    channel = metadb.channelmap(on=date, system="cal").V02160A
+    channel = metadb.channelmap(on=date, category="cal").V02160A
+    assert "analysis" in channel
+
+    # the deprecated 'system' alias must still work
+    with pytest.warns(DeprecationWarning, match="'system' argument is deprecated"):
+        channel = metadb.channelmap(on=date, system="cal").V02160A
     assert "analysis" in channel
 
     metadb.checkout("8c311d5")
     metadb.scan()
-    channel = metadb.channelmap(on=date, system="cal").V02160A
+    channel = metadb.channelmap(on=date, category="cal").V02160A
     assert "analysis" in channel
 
 


### PR DESCRIPTION
dbetto 1.4.0 renamed the `system` keyword of `TextDB.on()` (and the channelmap helpers) to `category`, keeping `system` as a deprecated alias that now emits a `DeprecationWarning`. Left unaddressed, every `channelmap()` / validity resolution call in pylegendmeta trips that warning (and fails tests that treat warnings as errors).

This PR:

- Passes `category` at all dbetto call sites (`legendmetadata.py`, `police.py`) and bumps the requirement to `dbetto>=1.4`.
- Renames `LegendMetadata.channelmap()`'s `system` parameter to `category`. Its accepted values (`all`, `phy`, `cal`, `lar`, ...) are data-taking categories, not detector systems (`geds`, `spms`, ...), so the old name was a misnomer. The old `system` keyword is kept as a deprecated alias emitting a `DeprecationWarning`, mirroring dbetto's own migration.
- Renames the misnamed `sy` local in `police.py` (it holds a category) and updates the docstring/tests accordingly. Genuine detector-"system" references (`chmap[det]["system"]`, `.group("system")`, the geds/spms/... templates) are left untouched.

Full test suite passes against dbetto 1.4.0 (151 passed), including a new assertion that the deprecated `system=` alias still works and warns.